### PR TITLE
Fix Android marker size

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -101,7 +101,7 @@ final class GoogleMapController
         new MethodChannel(binaryMessenger, "plugins.flutter.dev/google_maps_android_" + id);
     methodChannel.setMethodCallHandler(this);
     this.lifecycleProvider = lifecycleProvider;
-    this.markersController = new MarkersController(methodChannel, new CozyMarkerBuilder(174, 20, context));
+    this.markersController = new MarkersController(methodChannel, new CozyMarkerBuilder(context));
     this.polygonsController = new PolygonsController(methodChannel, density);
     this.polylinesController = new PolylinesController(methodChannel, density);
     this.circlesController = new CirclesController(methodChannel, density);


### PR DESCRIPTION
We noticed that the markers on Android are too big on devices with low resolution screens, so this PR adjusts the size of the markers making them responsive to the screen resolution

Before
![Screenshot_1667054433](https://user-images.githubusercontent.com/97969630/198837839-c04e5112-c8f9-4425-8e24-8c52290b3043.png)

After
![Screenshot_1667053280](https://user-images.githubusercontent.com/97969630/198837847-10224504-6c68-41f9-9c35-5dbfc993f124.png)

