### PR TITLE
feat(NX-1541): exposing map style parameter

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -119,6 +119,7 @@ class GoogleMap extends StatefulWidget {
     this.circles = const <Circle>{},
     this.onCameraMoveStarted,
     this.tileOverlays = const <TileOverlay>{},
+    this.style,
     this.onCameraMove,
     this.onCameraIdle,
     this.onTap,
@@ -197,6 +198,11 @@ class GoogleMap extends StatefulWidget {
 
   /// Tile overlays to be placed on the map.
   final Set<TileOverlay> tileOverlays;
+
+  /// JSON style to be applied on the map.
+  ///
+  /// See https://medium.com/@matthiasschuyten/google-maps-styling-in-flutter-5c4101806e83 for more details.
+  final String? style;
 
   /// Called when the camera starts moving.
   ///
@@ -412,9 +418,17 @@ class _GoogleMapState extends State<GoogleMap> {
     );
     _controller.complete(controller);
     _updateTileOverlays();
+    _setMapStyle();
     final MapCreatedCallback? onMapCreated = widget.onMapCreated;
     if (onMapCreated != null) {
       onMapCreated(controller);
+    }
+  }
+
+  Future<void> _setMapStyle() async {
+    if (widget.style != null) {
+      final GoogleMapController controller = await _controller.future;
+      controller.setMapStyle(widget.style);
     }
   }
 


### PR DESCRIPTION
## Description

This PR exposes an optional JSON String parameter to apply a specific style to the map.

## How to test

Set a custom map style when using `GoogleMap` widget. An example would be the following string, which turns roads to a dark gray and water to red.

```
const styleJson = '[{"elementType":"geometry","stylers":[{"color":"#f5f5f5"}]},{"featureType":"road","elementType":"geometry","stylers":[{"color":"#505050"}]},{"featureType":"water","elementType":"geometry","stylers":[{"color":"#FF0000"}]},{"featureType":"water","elementType":"labels.text.fill","stylers":[{"color":"#000000"}]}]'

GoogleMap(
    style: styleJson,
    ...
);
```

![telegram-cloud-photo-size-1-5026455949870738152-y](https://user-images.githubusercontent.com/40547661/211088212-7ec14050-4073-4e04-a361-8a69cd48fdce.jpg)
