### PR TITLE
feat(TA-00): new rounded marker

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -419,6 +419,7 @@ class Convert {
         sink.setIcon(toBitmapDescriptor(icon));
         break;
       case "price":
+      case "rounded":
       case "count":
         final Object label = data.get("label");
         if (label == null) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -73,11 +73,6 @@ public class CozyMarkerBuilder {
             return Math.max(proportionalMarkerSize, minMarkerSize);
     }
 
-    private int getBorderRadius(int multiply) {
-        double density = Resources.getSystem().getDisplayMetrics().density;
-        return (int) (density * multiply);
-    }
-
     private Bitmap getEmptyClusterBitmap(int size) {
         Bitmap marker = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(marker);
@@ -86,7 +81,7 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    private Bitmap getClusterMarker(String text) {
+    private Bitmap getClusterMarkerBitmap(String text) {
         Bitmap marker = Bitmap.createBitmap(this.blankClusterMarker);
         Rect clusterRect = new Rect();
         clusterTextStyle.getTextBounds(text, 0, text.length(), clusterRect);
@@ -109,7 +104,7 @@ public class CozyMarkerBuilder {
         return pointer;
     }
 
-    private Bitmap getPriceMarker(String text) {
+    private Bitmap getPriceMarkerBitmap(String text) {
         Rect rect = new Rect();
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
 
@@ -124,9 +119,8 @@ public class CozyMarkerBuilder {
 
         Canvas canvas = new Canvas(marker);
 
-        int borderRadius = getBorderRadius(5);
-        int shadowBorderRadius = getBorderRadius(10);
-        canvas.drawRoundRect(shadow, shadowBorderRadius, shadowBorderRadius, getShadowPaint());
+        int borderRadius = 20;
+        canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint());
         canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint());
         canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint());
 
@@ -136,15 +130,15 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    private float getTextYOffset(float height, Rect rect) {
-        return (height / 2f) + (rect.height() / 2f) - rect.bottom;
+    private float getTextYOffset(float markerHeight, Rect rect) {
+        return (markerHeight / 2f) + (rect.height() / 2f) - rect.bottom;
     }
 
-    private float getTextXOffset(float width, Rect rect) {
-        return (width / 2f) - (rect.width() / 2f) - rect.left;
+    private float getTextXOffset(float markerWidth, Rect rect) {
+        return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
     }
 
-    private Bitmap getRoundedMarker(String text) {
+    private Bitmap getRoundedMarkerBitmap(String text) {
         Rect rect = new Rect();
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
         int minWidth = Math.max(rect.width(), size / 2);
@@ -156,10 +150,9 @@ public class CozyMarkerBuilder {
         RectF shadow = new RectF(0, 0, markerWidth, markerHeight);
         RectF shape = new RectF(shadowSize, shadowSize, markerWidth - shadowSize, markerHeight - shadowSize);
 
-        int borderRadius = getBorderRadius(15);
-        int shadowRadius = getBorderRadius(20);
+        int borderRadius = 40;
         Canvas canvas = new Canvas(marker);
-        canvas.drawRoundRect(shadow, shadowRadius, shadowRadius, getShadowPaint());
+        canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint());
         canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint());
 
         float dx = getTextXOffset(markerWidth, rect);
@@ -172,11 +165,11 @@ public class CozyMarkerBuilder {
     public Bitmap buildMarker(String type, String text) {
         switch (type) {
             case "count":
-                return getClusterMarker(text);
+                return getClusterMarkerBitmap(text);
             case "price":
-                return getPriceMarker(text);
+                return getPriceMarkerBitmap(text);
             case "rounded":
-                return getRoundedMarker(text);
+                return getRoundedMarkerBitmap(text);
             default:
                 return null;
         }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
@@ -15,13 +15,15 @@ NS_ASSUME_NONNULL_BEGIN
                             identifier:(NSString *)identifier
                                mapView:(GMSMapView *)mapView
                              iconImage:(UIImage *)iconImage
-                             fontPath:(NSString *)path;
+                              fontPath:(nonnull NSString *)fontPath
+                              markerRadius:(CGFloat)radius;
 - (void)showInfoWindow;
 - (void)hideInfoWindow;
 - (BOOL)isInfoWindowShown;
 - (void)removeMarker;
 - (UIImage *)clusterMarkerImageWithText:(NSString *)text;
 - (UIImage *)priceMarkerImageWithText:(NSString *)text;
+- (UIImage *)roundedMarkerImageWithText:(NSString *)text;
 @end
 
 @interface FLTMarkersController : NSObject

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
@@ -15,13 +15,17 @@ Object _offsetToJson(Offset offset) {
 
 /// The type of marker icon which should be displayed.
 enum MarkerType {
-  /// A white round circle with text in the middle. If chosen, an label must
+  /// A white circle with text in the middle. If chosen, an label must
   /// be passed in the label argument.
   count,
 
   /// A white text bubble with text in the middle. The bubble adjusts itself
   /// to the text. If chosen, an label must be passed in the label argument.
   price,
+
+  /// A white rounded square with text in the middle. The shape adjusts itself
+  /// to the text. If chosen, an label must be passed in the label argument.
+  rounded,
 
   /// A non-standard icon. If chosen, an icon must be passed in the icon
   /// argument.
@@ -141,6 +145,8 @@ class Marker implements MapsObject<Marker> {
   /// Specifies a marker that
   /// * is fully opaque; [alpha] is 1.0
   /// * uses icon bottom center to indicate map position; [anchor] is (0.5, 1.0)
+  /// * has a pre-set marker type or a customized one; [markerType] is (icon, count, rounded, price)
+  /// * has a text to be added in case the marker type is count or price.
   /// * has default tap handling; [consumeTapEvents] is false
   /// * is stationary; [draggable] is false
   /// * is drawn against the screen, not the map; [flat] is false


### PR DESCRIPTION
This PR adds a new round default marker to the map.

iOS (iPhone):
<img width="390" alt="image" src="https://user-images.githubusercontent.com/109806620/213293371-e9110440-c51f-4f8b-aa57-543ad9ee8c0b.png">

iOS (iPad):
<img width="606" alt="image" src="https://user-images.githubusercontent.com/109806620/215880468-a9c61828-abdf-4ae8-9825-4c4ad77aaeb4.png">


Android (phone):
<img width="390" alt="image" src="https://user-images.githubusercontent.com/109806620/213318340-bd8eded1-549c-427a-acbf-c63eb4c6f560.png">

Android (tablet):
<img width="490" alt="image" src="https://user-images.githubusercontent.com/109806620/215907703-c4167a27-7084-4aa1-a7e9-428edf58bb2f.png">

