### PR TITLE
feat(TA-2457): adding visited and selected markers

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -420,6 +420,8 @@ class Convert {
         break;
       case "price":
       case "rounded":
+      case "rounded_selected":
+      case "rounded_visited":
       case "count":
         final Object label = data.get("label");
         if (label == null) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.Typeface;
 
 import androidx.core.content.res.ResourcesCompat;
 
@@ -18,31 +19,29 @@ public class CozyMarkerBuilder {
     private final int padding;
     private final int size;
     private final Bitmap blankClusterMarker;
-    private final Paint clusterTextStyle;
-    private final Paint priceMarkerTextStyle;
+    private final Typeface font;
 
     CozyMarkerBuilder(Context context) {
         size = getMarkerSize();
         padding = size / 3;
         priceMarkerTailSize = size / 6;
         blankClusterMarker = getEmptyClusterBitmap(size);
-        clusterTextStyle = getTextPaint(size / 3f, context);
-        priceMarkerTextStyle = getTextPaint(size / 3.5f, context);
+        font = ResourcesCompat.getFont(context, R.font.oatmealpro2_semibold);
     }
 
-    private Paint getTextPaint(float size, Context context) {
+    private Paint getTextPaint(float size, int color) {
         Paint paint = new Paint();
-        paint.setColor(Color.BLACK);
-        paint.setTypeface(ResourcesCompat.getFont(context, R.font.oatmealpro2_semibold));
+        paint.setColor(color);
+        paint.setTypeface(font);
         paint.setTextSize(size);
         paint.setAntiAlias(true);
         paint.setTextAlign(Paint.Align.LEFT);
         return paint;
     }
 
-    private Paint getMarkerPaint() {
+    private Paint getMarkerPaint(int color) {
         Paint paint = new Paint();
-        paint.setColor(Color.WHITE);
+        paint.setColor(color);
         paint.setAntiAlias(true);
         return paint;
     }
@@ -82,17 +81,19 @@ public class CozyMarkerBuilder {
         Bitmap marker = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(marker);
         canvas.drawCircle(size / 2f, size / 2f, size / 2.2f, getShadowPaint());
-        canvas.drawCircle(size / 2f, size / 2f, (size / 2.2f) - shadowSize, getMarkerPaint());
+        canvas.drawCircle(size / 2f, size / 2f, (size / 2.2f) - shadowSize, getMarkerPaint(Color.WHITE));
         return marker;
     }
 
     private Bitmap getClusterMarker(String text) {
         Bitmap marker = Bitmap.createBitmap(this.blankClusterMarker);
         Rect clusterRect = new Rect();
+        Paint clusterTextStyle = getTextPaint(size / 3f, Color.BLACK);
         clusterTextStyle.getTextBounds(text, 0, text.length(), clusterRect);
         float dx = getTextXOffset(marker.getWidth(), clusterRect);
         float dy = getTextYOffset(marker.getHeight(), clusterRect);
-        new Canvas(marker).drawText(text, dx, dy, clusterTextStyle);
+        Canvas canvas = new Canvas(marker);
+        canvas.drawText(text, dx, dy, clusterTextStyle);
         return marker;
     }
 
@@ -111,6 +112,7 @@ public class CozyMarkerBuilder {
 
     private Bitmap getPriceMarker(String text) {
         Rect rect = new Rect();
+        Paint priceMarkerTextStyle = getTextPaint(size / 3.5f, Color.BLACK);
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
 
         int width = rect.width() + padding;
@@ -127,8 +129,8 @@ public class CozyMarkerBuilder {
         int borderRadius = getBorderRadius(5);
         int shadowBorderRadius = getBorderRadius(10);
         canvas.drawRoundRect(shadow, shadowBorderRadius, shadowBorderRadius, getShadowPaint());
-        canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint());
-        canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint());
+        canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint(Color.WHITE));
+        canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint(Color.WHITE));
 
         float dx = getTextXOffset(width, rect);
         float dy = getTextYOffset(height, rect);
@@ -144,8 +146,9 @@ public class CozyMarkerBuilder {
         return (width / 2f) - (rect.width() / 2f) - rect.left;
     }
 
-    private Bitmap getRoundedMarker(String text) {
+    private Bitmap getRoundedMarker(String text, int markerColor, int textColor) {
         Rect rect = new Rect();
+        Paint priceMarkerTextStyle = getTextPaint(size / 3.5f, textColor);
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
         int minWidth = Math.max(rect.width(), size / 2);
 
@@ -160,7 +163,7 @@ public class CozyMarkerBuilder {
         int shadowRadius = getBorderRadius(20);
         Canvas canvas = new Canvas(marker);
         canvas.drawRoundRect(shadow, shadowRadius, shadowRadius, getShadowPaint());
-        canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint());
+        canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint(markerColor));
 
         float dx = getTextXOffset(markerWidth, rect);
         float dy = getTextYOffset(markerHeight, rect);
@@ -176,7 +179,11 @@ public class CozyMarkerBuilder {
             case "price":
                 return getPriceMarker(text);
             case "rounded":
-                return getRoundedMarker(text);
+                return getRoundedMarker(text, Color.WHITE, Color.BLACK);
+            case "rounded_selected":
+                return getRoundedMarker(text, Color.rgb(57, 87, 189), Color.WHITE);
+            case "rounded_visited":
+                return getRoundedMarker(text, Color.WHITE, Color.rgb(110, 110, 100));
             default:
                 return null;
         }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -161,7 +161,7 @@
     return image;
 }
 
-- (UIImage *)roundedMarkerImageWithText:(NSString *)text {
+- (UIImage *)roundedMarkerImageWithText:(NSString *)text withMarkerColor:(UIColor *)color withTextColor:(UIColor *)textColor {
     UIFont *textFont =  [UIFont fontWithName:self.fontPath size:[_iconImage size].width / 3.5];
     CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
     
@@ -187,7 +187,7 @@
         [shadow fill];
         [shadow stroke];
         CGContextSetAlpha(rendererContext.CGContext, 1.0);
-        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, color.CGColor);
         CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
         CGContextSetLineWidth(rendererContext.CGContext, 5);
         CGContextSetLineJoin(rendererContext.CGContext, 0);
@@ -195,7 +195,7 @@
         UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(shadowSize / 2, shadowSize / 2, markerWidth - shadowSize, markerHeight - shadowSize) cornerRadius:20];
         [bezier fill];
         [bezier stroke];
-        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
+        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont, NSForegroundColorAttributeName: textColor}];
     }];
     UIGraphicsEndImageContext();
     return image;
@@ -240,8 +240,8 @@
         } else if([markerType isEqualToString:@"rounded"]) {
             NSString *label = data[@"label"];
             if(label && label != (id)[NSNull null]) {
-                UIImage *img = [self roundedMarkerImageWithText:label];
-                [self setIcon:img];
+                UIImage *image = [self roundedMarkerImageWithText:label withMarkerColor:UIColor.whiteColor withTextColor:UIColor.blackColor];
+                [self setIcon:image];
             } else {
                 NSString *error =
                 [NSString stringWithFormat:@"label was not provided."];
@@ -249,8 +249,35 @@
                                                                  reason:error
                                                                userInfo:nil];
                 @throw exception;
-            }           
+            }
+         }else if([markerType isEqualToString:@"rounded_visited"]) {
+            NSString *label = data[@"label"];
+            if(label && label != (id)[NSNull null]) {
+                UIImage *image = [self roundedMarkerImageWithText:label withMarkerColor:UIColor.whiteColor withTextColor:[UIColor colorWithRed:(110.0f/255.0f) green:(110.0f/255.0f) blue:(100.0f/255.0f) alpha:1]];
+                [self setIcon:image];
+            } else {
+                NSString *error =
+                [NSString stringWithFormat:@"label was not provided."];
+                NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
+                                                                 reason:error
+                                                               userInfo:nil];
+                @throw exception;
+            }
          }
+        else if([markerType isEqualToString:@"rounded_selected"]) {
+           NSString *label = data[@"label"];
+           if(label && label != (id)[NSNull null]) {
+               UIImage *image = [self roundedMarkerImageWithText:label withMarkerColor:[UIColor colorWithRed:(57.0f/255.0f) green:(87.0f/255.0f) blue:(189.0f/255.0f) alpha:1] withTextColor:UIColor.whiteColor];
+               [self setIcon:image];
+           } else {
+               NSString *error =
+               [NSString stringWithFormat:@"label was not provided."];
+               NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
+                                                                reason:error
+                                                              userInfo:nil];
+               @throw exception;
+           }
+        }
         else if([markerType isEqualToString:@"price"]) {
             NSString *label = data[@"label"];
             if(label && label != (id)[NSNull null]) {


### PR DESCRIPTION
This PR adds two more markers to android and iOS:

- The rounded selected marker 
![image](https://user-images.githubusercontent.com/109806620/215120942-da20febc-b8a1-4157-a0af-beddb0d34473.png)
- The rounded visited marker
![image](https://user-images.githubusercontent.com/109806620/215121022-8678918e-25a9-4c8f-b2a3-ad25b85245c2.png)
