### PR TITLE
chore(TA-000): bump refs

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.2
+      ref: v2.2.1-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: main
+      ref: v2.2.1-fork.2
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0


### PR DESCRIPTION
This PR sets refs to a new tag so when using it in apps all plugins will call the tag instead of the main branch.