### PR TITLE
feat(TA-00): caching markers to reuse and reduce processing

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -106,6 +106,7 @@ class GoogleMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.myLocationEnabled = false,
     this.myLocationButtonEnabled = true,
+    this.cacheMarkers = false,
     this.layoutDirection,
 
     /// If no padding is specified default padding will be 0.
@@ -134,6 +135,9 @@ class GoogleMap extends StatefulWidget {
 
   /// The initial position of the map's camera.
   final CameraPosition initialCameraPosition;
+
+  /// True if the map should cache markers when displaying the map.
+  final bool cacheMarkers;
 
   /// True if the map should show a compass when rotated.
   final bool compassEnabled;
@@ -549,6 +553,7 @@ class _GoogleMapState extends State<GoogleMap> {
 MapConfiguration _configurationFromMapWidget(GoogleMap map) {
   assert(!map.liteModeEnabled || Platform.isAndroid);
   return MapConfiguration(
+    cacheMarkers: map.cacheMarkers,
     compassEnabled: map.compassEnabled,
     mapToolbarEnabled: map.mapToolbarEnabled,
     cameraTargetBounds: map.cameraTargetBounds,

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -136,7 +136,7 @@ class GoogleMap extends StatefulWidget {
   /// The initial position of the map's camera.
   final CameraPosition initialCameraPosition;
 
-  /// True if the map should cache markers when displaying the map.
+  /// If `true`, will cache markers when displaying the map for improved performance.
   final bool enableMarkerCaching;
 
   /// True if the map should show a compass when rotated.

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -106,7 +106,7 @@ class GoogleMap extends StatefulWidget {
     this.tiltGesturesEnabled = true,
     this.myLocationEnabled = false,
     this.myLocationButtonEnabled = true,
-    this.cacheMarkers = false,
+    this.enableMarkerCaching = false,
     this.layoutDirection,
 
     /// If no padding is specified default padding will be 0.
@@ -137,7 +137,7 @@ class GoogleMap extends StatefulWidget {
   final CameraPosition initialCameraPosition;
 
   /// True if the map should cache markers when displaying the map.
-  final bool cacheMarkers;
+  final bool enableMarkerCaching;
 
   /// True if the map should show a compass when rotated.
   final bool compassEnabled;
@@ -553,7 +553,7 @@ class _GoogleMapState extends State<GoogleMap> {
 MapConfiguration _configurationFromMapWidget(GoogleMap map) {
   assert(!map.liteModeEnabled || Platform.isAndroid);
   return MapConfiguration(
-    cacheMarkers: map.cacheMarkers,
+    enableMarkerCaching: map.enableMarkerCaching,
     compassEnabled: map.compassEnabled,
     mapToolbarEnabled: map.mapToolbarEnabled,
     cameraTargetBounds: map.cameraTargetBounds,

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -378,6 +378,10 @@ class Convert {
     if (buildingsEnabled != null) {
       sink.setBuildingsEnabled(toBoolean(buildingsEnabled));
     }
+    final Object cacheMarkers = data.get("cacheMarkers");
+    if(cacheMarkers != null) {
+      sink.setMarkerCachingEnabled(toBoolean(cacheMarkers));
+    }
   }
 
   /** Returns the dartMarkerId of the interpreted marker. */

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -378,9 +378,9 @@ class Convert {
     if (buildingsEnabled != null) {
       sink.setBuildingsEnabled(toBoolean(buildingsEnabled));
     }
-    final Object cacheMarkers = data.get("cacheMarkers");
-    if(cacheMarkers != null) {
-      sink.setMarkerCachingEnabled(toBoolean(cacheMarkers));
+    final Object enableMarkerCaching = data.get("enableMarkerCaching");
+    if (enableMarkerCaching != null) {
+      sink.setMarkerCachingEnabled(toBoolean(enableMarkerCaching));
     }
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -176,6 +176,7 @@ public class CozyMarkerBuilder {
     }
 
     private Bitmap copyOnlyBitmapProperties(Bitmap bitmap) {
+        if (bitmap == null) return null;
         return bitmap.copy(bitmap.getConfig(), true);
     }
 
@@ -195,8 +196,11 @@ public class CozyMarkerBuilder {
     }
 
     public Bitmap buildMarker(String type, String text) {
-        Bitmap marker = markerCache != null ? bitmapWithCache(type, text) : getMarker(type, text);
-        if(marker == null) return null;
+        if(markerCache != null) {
+            final Bitmap marker = bitmapWithCache(type, text);
+            return copyOnlyBitmapProperties(marker);
+        }
+        final Bitmap marker = getMarker(type, text);
         return copyOnlyBitmapProperties(marker);
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -13,6 +13,7 @@ import android.graphics.Typeface;
 
 import androidx.core.content.res.ResourcesCompat;
 
+
 public class CozyMarkerBuilder {
     private final int shadowSize = 3;
     private final int priceMarkerTailSize;
@@ -123,8 +124,8 @@ public class CozyMarkerBuilder {
 
         int borderRadius = 20;
         canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint());
-        canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint());
-        canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint());
+        canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint(Color.WHITE));
+        canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint(Color.WHITE));
 
         float dx = getTextXOffset(width, rect);
         float dy = getTextYOffset(height, rect);
@@ -156,7 +157,7 @@ public class CozyMarkerBuilder {
         int borderRadius = 40;
         Canvas canvas = new Canvas(marker);
         canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint());
-        canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint());
+        canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint(markerColor));
 
         float dx = getTextXOffset(markerWidth, rect);
         float dy = getTextYOffset(markerHeight, rect);

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -177,14 +177,18 @@ public class CozyMarkerBuilder {
         }
     }
 
+    private Bitmap copyOnlyBitmapProperties(Bitmap bitmap) {
+        return bitmap.copy(bitmap.getConfig(), true);
+    }
+
     public Bitmap buildMarker(String type, String text) {
         String key = String.format("%s:%s", type, text);
         final Bitmap bitmap = markerCache.getBitmapFromMemCache(key);
         if (bitmap != null) {
-            return bitmap.copy(bitmap.getConfig(), true);
+            return copyOnlyBitmapProperties(bitmap);
         }
         Bitmap marker = getMarker(type, text);
         markerCache.addBitmapToMemoryCache(key, marker);
-        return marker.copy(marker.getConfig(), true);
+        return copyOnlyBitmapProperties(marker);
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -97,11 +97,6 @@ public class CozyMarkerBuilder {
             return Math.max(proportionalMarkerSize, minMarkerSize);
     }
 
-    private int getBorderRadius(int multiply) {
-        double density = Resources.getSystem().getDisplayMetrics().density;
-        return (int) (density * multiply);
-    }
-
     private Bitmap getEmptyClusterBitmap(int size) {
         Bitmap marker = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(marker);
@@ -110,7 +105,7 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    private Bitmap getClusterMarker(String text) {
+    private Bitmap getClusterMarkerBitmap(String text) {
         Bitmap marker = Bitmap.createBitmap(this.blankClusterMarker);
         Rect clusterRect = new Rect();
         clusterTextStyle.getTextBounds(text, 0, text.length(), clusterRect);
@@ -134,7 +129,7 @@ public class CozyMarkerBuilder {
         return pointer;
     }
 
-    private Bitmap getPriceMarker(String text) {
+    private Bitmap getPriceMarkerBitmap(String text) {
         Rect rect = new Rect();
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
 
@@ -149,10 +144,8 @@ public class CozyMarkerBuilder {
 
         Canvas canvas = new Canvas(marker);
 
-        int borderRadius = getBorderRadius(5);
-        int shadowBorderRadius = getBorderRadius(10);
-        canvas.drawRoundRect(shadow, shadowBorderRadius, shadowBorderRadius, getShadowPaint());
-        canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint());
+        canvas.drawRoundRect(shadow, 20, 20, getShadowPaint());
+        canvas.drawRoundRect(bubble, 20, 20, getMarkerPaint());
         canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint());
 
         float dx = getTextXOffset(width, rect);
@@ -161,15 +154,15 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    private float getTextYOffset(float height, Rect rect) {
-        return (height / 2f) + (rect.height() / 2f) - rect.bottom;
+    private float getTextYOffset(float markerHeight, Rect rect) {
+        return (markerHeight / 2f) + (rect.height() / 2f) - rect.bottom;
     }
 
-    private float getTextXOffset(float width, Rect rect) {
-        return (width / 2f) - (rect.width() / 2f) - rect.left;
+    private float getTextXOffset(float markerWidth, Rect rect) {
+        return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
     }
 
-    private Bitmap getRoundedMarker(String text) {
+    private Bitmap getRoundedMarkerBitmap(String text) {
         Rect rect = new Rect();
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
         int minWidth = Math.max(rect.width(), size / 2);
@@ -181,11 +174,9 @@ public class CozyMarkerBuilder {
         RectF shadow = new RectF(0, 0, markerWidth, markerHeight);
         RectF shape = new RectF(shadowSize, shadowSize, markerWidth - shadowSize, markerHeight - shadowSize);
 
-        int borderRadius = getBorderRadius(15);
-        int shadowRadius = getBorderRadius(20);
         Canvas canvas = new Canvas(marker);
-        canvas.drawRoundRect(shadow, shadowRadius, shadowRadius, getShadowPaint());
-        canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint());
+        canvas.drawRoundRect(shadow, 40, 40, getShadowPaint());
+        canvas.drawRoundRect(shape, 40, 40, getMarkerPaint());
 
         float dx = getTextXOffset(markerWidth, rect);
         float dy = getTextYOffset(markerHeight, rect);
@@ -197,11 +188,11 @@ public class CozyMarkerBuilder {
     private Bitmap getMarker(String type, String text) {
         switch (type) {
             case "count":
-                return getClusterMarker(text);
+                return getClusterMarkerBitmap(text);
             case "price":
-                return getPriceMarker(text);
+                return getPriceMarkerBitmap(text);
             case "rounded":
-                return getRoundedMarker(text);
+                return getRoundedMarkerBitmap(text);
             default:
                 return null;
         }
@@ -215,6 +206,6 @@ public class CozyMarkerBuilder {
         }
         Bitmap marker = getMarker(type, text);
         addBitmapToMemoryCache(key, marker);
-        return marker;
+        return marker.copy(marker.getConfig(), true);
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -208,12 +208,13 @@ public class CozyMarkerBuilder {
     }
 
     public Bitmap buildMarker(String type, String text) {
-        final Bitmap bitmap = getBitmapFromMemCache(text);
+        String key = String.format("%s:%s", type, text);
+        final Bitmap bitmap = getBitmapFromMemCache(key);
         if (bitmap != null) {
             return bitmap.copy(bitmap.getConfig(), true);
         }
         Bitmap marker = getMarker(type, text);
-        addBitmapToMemoryCache(text, marker);
+        addBitmapToMemoryCache(key, marker);
         return marker;
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -44,13 +44,13 @@ public class CozyMarkerBuilder {
         };
     }
 
-    public void addBitmapToMemoryCache(String key, Bitmap bitmap) {
+    private void addBitmapToMemoryCache(String key, Bitmap bitmap) {
         if (getBitmapFromMemCache(key) == null) {
             memoryCache.put(key, bitmap);
         }
     }
 
-    public Bitmap getBitmapFromMemCache(String key) {
+    private Bitmap getBitmapFromMemCache(String key) {
         return memoryCache.get(key);
     }
 
@@ -194,7 +194,7 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    public Bitmap getMarker(String type, String text) {
+    private Bitmap getMarker(String type, String text) {
         switch (type) {
             case "count":
                 return getClusterMarker(text);

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -21,6 +21,7 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   private boolean indoorEnabled = true;
   private boolean trafficEnabled = false;
   private boolean buildingsEnabled = true;
+  private boolean markerCachingEnabled = false;
   private Object initialMarkers;
   private Object initialPolygons;
   private Object initialPolylines;
@@ -33,8 +34,8 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
       Context context,
       BinaryMessenger binaryMessenger,
       LifecycleProvider lifecycleProvider) {
-    final GoogleMapController controller =
-        new GoogleMapController(id, context, binaryMessenger, lifecycleProvider, options);
+    final GoogleMapController controller = new GoogleMapController(id, context, binaryMessenger, lifecycleProvider,
+        options);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationButtonEnabled(myLocationButtonEnabled);
@@ -48,6 +49,7 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
     controller.setInitialCircles(initialCircles);
     controller.setPadding(padding.top, padding.left, padding.bottom, padding.right);
     controller.setInitialTileOverlays(initialTileOverlays);
+    controller.setMarkerCachingEnabled(markerCachingEnabled);
     return controller;
   }
 
@@ -173,5 +175,10 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   @Override
   public void setInitialTileOverlays(List<Map<String, ?>> initialTileOverlays) {
     this.initialTileOverlays = initialTileOverlays;
+  }
+
+  @Override
+  public void setMarkerCachingEnabled(boolean isEnabled) {
+    this.markerCachingEnabled = isEnabled;
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -69,7 +69,6 @@ final class GoogleMapController
   private boolean indoorEnabled = true;
   private boolean trafficEnabled = false;
   private boolean buildingsEnabled = true;
-  private boolean markerCachingEnabled = false;
   private boolean disposed = false;
   private final float density;
   private MethodChannel.Result mapReadyResult;

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -69,6 +69,7 @@ final class GoogleMapController
   private boolean indoorEnabled = true;
   private boolean trafficEnabled = false;
   private boolean buildingsEnabled = true;
+  private boolean markerCachingEnabled = false;
   private boolean disposed = false;
   private final float density;
   private MethodChannel.Result mapReadyResult;
@@ -79,6 +80,7 @@ final class GoogleMapController
   private final PolylinesController polylinesController;
   private final CirclesController circlesController;
   private final TileOverlaysController tileOverlaysController;
+  private final CozyMarkerBuilder cozyMarkerBuilder;
   private List<Object> initialMarkers;
   private List<Object> initialPolygons;
   private List<Object> initialPolylines;
@@ -95,13 +97,14 @@ final class GoogleMapController
     this.id = id;
     this.context = context;
     this.options = options;
+    this.cozyMarkerBuilder = new CozyMarkerBuilder(context);
     this.mapView = new MapView(context, options);
     this.density = context.getResources().getDisplayMetrics().density;
     methodChannel =
         new MethodChannel(binaryMessenger, "plugins.flutter.dev/google_maps_android_" + id);
     methodChannel.setMethodCallHandler(this);
     this.lifecycleProvider = lifecycleProvider;
-    this.markersController = new MarkersController(methodChannel, new CozyMarkerBuilder(context));
+    this.markersController = new MarkersController(methodChannel, this.cozyMarkerBuilder);
     this.polygonsController = new PolygonsController(methodChannel, density);
     this.polylinesController = new PolylinesController(methodChannel, density);
     this.circlesController = new CirclesController(methodChannel, density);
@@ -907,5 +910,9 @@ final class GoogleMapController
 
   public void setBuildingsEnabled(boolean buildingsEnabled) {
     this.buildingsEnabled = buildingsEnabled;
+  }
+
+  public void setMarkerCachingEnabled(boolean cachingEnabled) {
+    this.cozyMarkerBuilder.setCachingEnabled(cachingEnabled);
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
@@ -55,4 +55,6 @@ interface GoogleMapOptionsSink {
   void setInitialCircles(Object initialCircles);
 
   void setInitialTileOverlays(List<Map<String, ?>> initialTileOverlays);
+
+  void setMarkerCachingEnabled(boolean toBoolean);
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkerCache.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkerCache.java
@@ -10,7 +10,8 @@ public class MarkerCache {
     public MarkerCache() {
         int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
         int cacheSize = maxMemory / 8;
-        memoryCache = new LruCache<String, Bitmap>(cacheSize) {};
+        memoryCache = new LruCache<String, Bitmap>(cacheSize) {
+        };
     }
 
     public void addBitmapToMemoryCache(String key, Bitmap bitmap) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkerCache.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkerCache.java
@@ -1,0 +1,26 @@
+package io.flutter.plugins.googlemaps;
+
+import android.graphics.Bitmap;
+import android.util.LruCache;
+
+public class MarkerCache {
+
+    private final LruCache<String, Bitmap> memoryCache;
+
+    public MarkerCache() {
+        int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
+        int cacheSize = maxMemory / 8;
+        memoryCache = new LruCache<String, Bitmap>(cacheSize) {};
+    }
+
+    public void addBitmapToMemoryCache(String key, Bitmap bitmap) {
+        if (getBitmapFromMemCache(key) == null) {
+            memoryCache.put(key, bitmap);
+        }
+    }
+
+    public Bitmap getBitmapFromMemCache(String key) {
+        return memoryCache.get(key);
+    }
+
+}

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -630,6 +630,7 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
 Map<String, Object> _jsonForMapConfiguration(MapConfiguration config) {
   final EdgeInsets? padding = config.padding;
   return <String, Object>{
+    if (config.cacheMarkers != null) 'cacheMarkers': config.cacheMarkers!,
     if (config.compassEnabled != null) 'compassEnabled': config.compassEnabled!,
     if (config.mapToolbarEnabled != null)
       'mapToolbarEnabled': config.mapToolbarEnabled!,

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -630,7 +630,8 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
 Map<String, Object> _jsonForMapConfiguration(MapConfiguration config) {
   final EdgeInsets? padding = config.padding;
   return <String, Object>{
-    if (config.cacheMarkers != null) 'cacheMarkers': config.cacheMarkers!,
+    if (config.enableMarkerCaching != null)
+      'enableMarkerCaching': config.enableMarkerCaching!,
     if (config.compassEnabled != null) 'compassEnabled': config.compassEnabled!,
     if (config.mapToolbarEnabled != null)
       'mapToolbarEnabled': config.mapToolbarEnabled!,

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/Runner.xcodeproj/project.pbxproj
@@ -412,10 +412,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh",
 				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/google_maps_flutter_ios/CozyFonts.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMaps.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/CozyFonts.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.h
@@ -8,12 +8,13 @@
 #import <CoreText/CoreText.h>
 
 @interface CozyMarkerBuilder : NSObject
-- (instancetype) initCozy;
+- (instancetype) initWithCache:(BOOL)useCache;
 - (UIImage *) buildMarker:(NSString *)label withMarkerType:(NSString *)markerType;
 
 @property(strong, nonatomic) NSCache *cache;
 @property(strong, nonatomic) NSString *fontPath;
 @property(nonatomic, assign) CGFloat markerSize;
 @property(nonatomic, assign) CGFloat shadowWidth;
+@property(nonatomic, assign) BOOL useCache;
 @end
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.h
@@ -1,0 +1,19 @@
+//
+//  CozyMarkerBuilder.h
+//  google_maps_flutter_ios-CozyFonts
+//
+//  Created by Luiz Carvalho on 16/02/23.
+//
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+
+@interface CozyMarkerBuilder : NSObject
+- (instancetype) initCozy;
+- (UIImage *) buildMarker:(NSString *)label withMarkerType:(NSString *)markerType;
+
+@property(strong, nonatomic) NSCache *cache;
+@property(strong, nonatomic) NSString *fontPath;
+@property(nonatomic, assign) CGFloat markerSize;
+@property(nonatomic, assign) CGFloat shadowWidth;
+@end
+

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -1,0 +1,235 @@
+//
+//  CozyMarkerBuilder.m
+//  google_maps_flutter_ios
+//
+//  Created by Luiz Carvalho on 16/02/23.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+#import "CozyMarkerBuilder.h"
+
+
+@implementation CozyMarkerBuilder
+
+
+- (instancetype)initCozy {
+    self = [super init];
+    if(self) {
+    _cache = [[NSCache alloc] init];
+    _fontPath = [self loadCozyFont];
+    _markerSize = [self calculateMarkerSize];
+    _shadowWidth = 5;
+    }
+    return self;
+}
+
+- (CGFloat)calculateMarkerSize {
+    CGFloat baseScreenHeight = 2220;
+    CGFloat maxMarkerRadius = 155;
+    CGFloat minMarkerRadius = 60;
+    CGFloat devicePixelRatio = [UIScreen mainScreen].bounds.size.height * [UIScreen mainScreen].scale;
+    CGFloat proportionalMarkerRadius = 150 * (devicePixelRatio / baseScreenHeight);
+    if(proportionalMarkerRadius > maxMarkerRadius) {
+        return maxMarkerRadius;
+    } else if (proportionalMarkerRadius < minMarkerRadius) {
+        return minMarkerRadius;
+    }
+    return proportionalMarkerRadius;
+}
+
+- (NSString *)loadCozyFont {
+    CGFontRef font = [self fontRefFromBundle];
+    [self registerFont:font];
+    NSString *fontName = (__bridge NSString *)CGFontCopyPostScriptName(font);
+    CFSafeRelease(font);
+    return fontName;
+}
+
+- (void)registerFont:(CGFontRef)font {
+    CFErrorRef error;
+    if (!CTFontManagerRegisterGraphicsFont(font, &error)) {
+        CFStringRef errorDescription = CFErrorCopyDescription(error);
+        NSLog(@"Failed to load font: %@", errorDescription);
+        CFRelease(errorDescription);
+    }
+}
+
+- (CGFontRef)fontRefFromBundle {
+    NSBundle *frameworkBundle = [NSBundle bundleForClass:self.classForCoder];
+    NSURL *bundleURL = [[frameworkBundle resourceURL] URLByAppendingPathComponent:@"CozyFonts.bundle"];
+    NSBundle *bundle = [NSBundle  bundleWithURL:bundleURL];
+    NSURL *fontURL = [bundle URLForResource:@"oatmealpro2_semibold" withExtension:@"otf"];
+    NSData *inData = [NSData dataWithContentsOfURL:fontURL];
+    CGDataProviderRef provider = CGDataProviderCreateWithCFData((CFDataRef)inData);
+    CGFontRef font = CGFontCreateWithDataProvider(provider);
+    CFSafeRelease(provider);
+    return font;
+}
+
+void CFSafeRelease(CFTypeRef cf) {
+    if (cf != NULL) {
+        CFRelease(cf);
+    }
+}
+
+- (UIImage *)baseClusterMarker {
+    CGFloat size = ([self markerSize] / [UIScreen mainScreen].scale) + [self shadowWidth];
+    CGSize canvas = CGSizeMake(size, size);
+    UIGraphicsBeginImageContext(canvas);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        CGContextSetAlpha(rendererContext.CGContext, 0.02);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
+        CGContextAddEllipseInRect(rendererContext.CGContext, CGRectMake(0, 0, size, size));
+        CGContextDrawPath(rendererContext.CGContext, kCGPathFillStroke);
+        CGContextSetAlpha(rendererContext.CGContext, 1.0);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
+        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
+        CGContextSetLineWidth(rendererContext.CGContext, 10);
+        CGContextAddEllipseInRect(rendererContext.CGContext, CGRectMake([self shadowWidth] / 2, [self shadowWidth] / 2, size - [self shadowWidth], size - [self shadowWidth]));
+        CGContextDrawPath(rendererContext.CGContext, kCGPathFillStroke);
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)clusterMarkerImageWithText:(NSString *)string {
+    UIImage *circle = [self baseClusterMarker];
+    CGSize size = [circle size];
+    UIFont *textFont = [UIFont fontWithName:self.fontPath size:size.width / 2.5];
+    CGSize stringSize = [string sizeWithAttributes:@{NSFontAttributeName:textFont}];
+    CGFloat textY = (size.height / 2) - (stringSize.height / 2);
+    CGFloat textX = (size.width / 2) - (stringSize.width / 2);
+    UIGraphicsBeginImageContext(size);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        CGRect rect = CGRectMake(0, 0, size.width, size.height);
+        [circle drawInRect:CGRectIntegral(rect)];
+        CGRect textRect = CGRectMake(textX, textY, stringSize.width, stringSize.height);
+        [string drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)priceMarkerImageWithText:(NSString *)text {
+    UIFont *textFont = [UIFont fontWithName:self.fontPath size:([self markerSize] / [UIScreen mainScreen].scale) / 3];
+    CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
+    CGFloat markerWidth = stringSize.width * 1.25;
+    CGFloat markerHeight = stringSize.height * 1.50;
+    CGSize canvas = CGSizeMake(markerWidth + 2, markerHeight + 10);
+    CGFloat y = ((canvas.height - 10) / 2) - (stringSize.height / 2);
+    CGFloat x = (canvas.width / 2) - (stringSize.width / 2);
+    CGRect textRect = CGRectMake(x, y, stringSize.width, stringSize.height);
+    UIGraphicsBeginImageContext(canvas);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        
+        CGFloat heightWithoutShadow = markerHeight - [self shadowWidth];
+        CGMutablePathRef path = CGPathCreateMutable();
+        CGPathMoveToPoint(path, nil, canvas.width / 2 - 10, heightWithoutShadow);
+        CGPathAddLineToPoint(path, nil, canvas.width / 2, heightWithoutShadow + 10);
+        CGPathAddLineToPoint(path, nil, canvas.width / 2 + 10, heightWithoutShadow);
+        CGPathAddLineToPoint(path, nil, canvas.width / 2 - 10, heightWithoutShadow);
+        
+        CGContextSetAlpha(rendererContext.CGContext, 0.02);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
+        UIBezierPath *shadow = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth, markerHeight) cornerRadius:7];
+        [shadow fill];
+        [shadow stroke];
+        CGContextSetAlpha(rendererContext.CGContext, 1.0);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
+        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
+        CGContextSetLineWidth(rendererContext.CGContext, 5);
+        CGContextSetLineJoin(rendererContext.CGContext, 0);
+        CGContextAddPath(rendererContext.CGContext, path);
+        CGContextDrawPath(rendererContext.CGContext, 3);
+        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake([self shadowWidth] / 2, [self shadowWidth] / 2, markerWidth - [self shadowWidth], markerHeight - [self shadowWidth]) cornerRadius:7];
+        [bezier fill];
+        [bezier stroke];
+        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
+        CGPathRelease(path);
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)roundedMarkerImageWithText:(NSString *)text withMarkerColor:(UIColor *)color withTextColor:(UIColor *)textColor {
+    UIFont *textFont =  [UIFont fontWithName:self.fontPath size:[self.baseClusterMarker size].width / 3.5];
+    CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
+    
+    CGFloat padding = 15;
+
+    CGFloat minMarkerWidth = ([self markerSize] / [UIScreen mainScreen].scale) / 2;
+    CGFloat markerWidth = ((stringSize.width > minMarkerWidth) ? stringSize.width : minMarkerWidth) + padding + [self shadowWidth];
+    CGFloat markerHeight = stringSize.height + padding + [self shadowWidth];
+
+    CGSize canvas = CGSizeMake(markerWidth, markerHeight);
+    CGFloat y = (canvas.height / 2) - (stringSize.height / 2);
+    CGFloat x = (canvas.width / 2) - (stringSize.width / 2);
+    CGRect textRect = CGRectMake(x, y, stringSize.width, stringSize.height);
+
+    UIGraphicsBeginImageContext(canvas);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        
+        CGContextSetAlpha(rendererContext.CGContext, 0.02);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
+        UIBezierPath *shadow = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth, markerHeight) cornerRadius:20];
+        [shadow fill];
+        [shadow stroke];
+        CGContextSetAlpha(rendererContext.CGContext, 1.0);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, color.CGColor);
+        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
+        CGContextSetLineWidth(rendererContext.CGContext, 5);
+        CGContextSetLineJoin(rendererContext.CGContext, 0);
+        CGContextDrawPath(rendererContext.CGContext, 3);
+        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake([self shadowWidth] / 2, [self shadowWidth] / 2, markerWidth - [self shadowWidth], markerHeight - [self shadowWidth]) cornerRadius:20];
+        [bezier fill];
+        [bezier stroke];
+        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont, NSForegroundColorAttributeName: textColor}];
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)getMarker:(NSString *)label withMarkerType:(NSString *)markerType {
+    if([markerType isEqualToString:@"count"]) {
+        return [self clusterMarkerImageWithText:label];
+    } else if([markerType isEqualToString:@"rounded"]) {
+        return [self roundedMarkerImageWithText:label withMarkerColor:UIColor.whiteColor withTextColor:UIColor.blackColor];
+    } else if([markerType isEqualToString:@"rounded_visited"]) {
+        return [self roundedMarkerImageWithText:label withMarkerColor:UIColor.whiteColor withTextColor:[UIColor colorWithRed:(110.0f/255.0f) green:(110.0f/255.0f) blue:(100.0f/255.0f) alpha:1]];
+    }
+    else if([markerType isEqualToString:@"rounded_selected"]) {
+        return [self roundedMarkerImageWithText:label withMarkerColor:[UIColor colorWithRed:(57.0f/255.0f) green:(87.0f/255.0f) blue:(189.0f/255.0f) alpha:1] withTextColor:UIColor.whiteColor];
+    }
+    else if([markerType isEqualToString:@"price"]) {
+        return [self priceMarkerImageWithText:label];
+    }
+    @throw [NSException exceptionWithName:@"InvalidMarker"
+                                       reason:@"markerType not found for icon."
+                                     userInfo:nil];
+    
+}
+
+- (UIImage *)buildMarker:(NSString *)label withMarkerType:(NSString *)markerType {
+    if(label == (id)[NSNull null] || [label isEqualToString:@""]) {
+        @throw [NSException exceptionWithName:@"InvalidMarker"
+                                       reason:@"no label was provided when expected."
+                                     userInfo:nil];
+    }
+    NSString *key = [NSString stringWithFormat:@"%@:%@", markerType, label];
+    UIImage *cachedImage = [[self cache] objectForKey:key];
+    if(cachedImage != nil) {
+        return cachedImage;
+    }
+    UIImage *image = [self getMarker:label withMarkerType:markerType];
+   
+    [[self cache] setObject:image forKey:key];
+    return image;
+}
+
+    
+@end

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -28,11 +28,11 @@
 }
 
 - (CGFloat)calculateMarkerSize {
-    CGFloat baseScreenHeight = 2220;
-    CGFloat maxMarkerRadius = 155;
-    CGFloat minMarkerRadius = 60;
+    CGFloat baseScreenHeight = 2467;
+    CGFloat maxMarkerRadius = 172;
+    CGFloat minMarkerRadius = 67;
     CGFloat devicePixelRatio = [UIScreen mainScreen].bounds.size.height * [UIScreen mainScreen].scale;
-    CGFloat proportionalMarkerRadius = 150 * (devicePixelRatio / baseScreenHeight);
+    CGFloat proportionalMarkerRadius = 167 * (devicePixelRatio / baseScreenHeight);
     if(proportionalMarkerRadius > maxMarkerRadius) {
         return maxMarkerRadius;
     } else if (proportionalMarkerRadius < minMarkerRadius) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.h
@@ -8,6 +8,7 @@
 #import "GoogleMapMarkerController.h"
 #import "GoogleMapPolygonController.h"
 #import "GoogleMapPolylineController.h"
+#import "CozyMarkerBuilder.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
@@ -5,6 +5,7 @@
 #import "GoogleMapController.h"
 #import "FLTGoogleMapJSONConversions.h"
 #import "FLTGoogleMapTileOverlayController.h"
+#import "CozyMarkerBuilder.h"
 
 #pragma mark - Conversion of JSON-like values sent via platform channels. Forward declarations.
 
@@ -107,7 +108,8 @@
     _registrar = registrar;
     _markersController = [[FLTMarkersController alloc] initWithMethodChannel:_channel
                                                                      mapView:_mapView
-                                                                   registrar:registrar];
+                                                                   registrar:registrar
+                                                           cozyMarkerBuilder:[[CozyMarkerBuilder alloc] initCozy]];
     _polygonsController = [[FLTPolygonsController alloc] init:_channel
                                                       mapView:_mapView
                                                     registrar:registrar];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
@@ -62,7 +62,7 @@
 @property(nonatomic, strong) GMSMapView *mapView;
 @property(nonatomic, strong) FlutterMethodChannel *channel;
 @property(nonatomic, assign) BOOL trackCameraPosition;
-@property(nonatomic, assign) BOOL cacheMarkers;
+@property(nonatomic, assign) BOOL enableMarkerCaching;
 @property(nonatomic, weak) NSObject<FlutterPluginRegistrar> *registrar;
 @property(nonatomic, strong) FLTMarkersController *markersController;
 @property(nonatomic, strong) FLTPolygonsController *polygonsController;
@@ -110,7 +110,7 @@
     _markersController = [[FLTMarkersController alloc] initWithMethodChannel:_channel
                                                                      mapView:_mapView
                                                                    registrar:registrar
-                                                           cozyMarkerBuilder:[[CozyMarkerBuilder alloc] initWithCache:_cacheMarkers]];
+                                                           cozyMarkerBuilder:[[CozyMarkerBuilder alloc] initWithCache:_enableMarkerCaching]];
     _polygonsController = [[FLTPolygonsController alloc] init:_channel
                                                       mapView:_mapView
                                                     registrar:registrar];
@@ -479,7 +479,7 @@
 }
 
 - (void)setCachingEnabled:(BOOL)enabled {
-  _cacheMarkers = enabled;
+  _enableMarkerCaching = enabled;
 }
 
 - (void)setZoomGesturesEnabled:(BOOL)enabled {
@@ -648,7 +648,7 @@
   if (myLocationButtonEnabled && myLocationButtonEnabled != (id)[NSNull null]) {
     [self setMyLocationButtonEnabled:[myLocationButtonEnabled boolValue]];
   }
-  NSNumber *isMarkerCachingEnabled = data[@"cacheMarkers"];
+  NSNumber *isMarkerCachingEnabled = data[@"enableMarkerCaching"];
   if (isMarkerCachingEnabled && isMarkerCachingEnabled != (id)[NSNull null]) {
     [self setCachingEnabled:[isMarkerCachingEnabled boolValue]];
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
@@ -62,6 +62,7 @@
 @property(nonatomic, strong) GMSMapView *mapView;
 @property(nonatomic, strong) FlutterMethodChannel *channel;
 @property(nonatomic, assign) BOOL trackCameraPosition;
+@property(nonatomic, assign) BOOL cacheMarkers;
 @property(nonatomic, weak) NSObject<FlutterPluginRegistrar> *registrar;
 @property(nonatomic, strong) FLTMarkersController *markersController;
 @property(nonatomic, strong) FLTPolygonsController *polygonsController;
@@ -109,7 +110,7 @@
     _markersController = [[FLTMarkersController alloc] initWithMethodChannel:_channel
                                                                      mapView:_mapView
                                                                    registrar:registrar
-                                                           cozyMarkerBuilder:[[CozyMarkerBuilder alloc] initCozy]];
+                                                           cozyMarkerBuilder:[[CozyMarkerBuilder alloc] initWithCache:_cacheMarkers]];
     _polygonsController = [[FLTPolygonsController alloc] init:_channel
                                                       mapView:_mapView
                                                     registrar:registrar];
@@ -477,6 +478,10 @@
   _trackCameraPosition = enabled;
 }
 
+- (void)setCachingEnabled:(BOOL)enabled {
+  _cacheMarkers = enabled;
+}
+
 - (void)setZoomGesturesEnabled:(BOOL)enabled {
   self.mapView.settings.zoomGestures = enabled;
 }
@@ -642,6 +647,10 @@
   NSNumber *myLocationButtonEnabled = data[@"myLocationButtonEnabled"];
   if (myLocationButtonEnabled && myLocationButtonEnabled != (id)[NSNull null]) {
     [self setMyLocationButtonEnabled:[myLocationButtonEnabled boolValue]];
+  }
+  NSNumber *isMarkerCachingEnabled = data[@"cacheMarkers"];
+  if (isMarkerCachingEnabled && isMarkerCachingEnabled != (id)[NSNull null]) {
+    [self setCachingEnabled:[isMarkerCachingEnabled boolValue]];
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
@@ -13,17 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(assign, nonatomic, readonly) BOOL consumeTapEvents;
 - (instancetype)initMarkerWithPosition:(CLLocationCoordinate2D)position
                             identifier:(NSString *)identifier
-                               mapView:(GMSMapView *)mapView
-                             iconImage:(UIImage *)iconImage
-                              fontPath:(nonnull NSString *)fontPath
-                              markerRadius:(CGFloat)radius;
+                               mapView:(GMSMapView *)mapView;
 - (void)showInfoWindow;
 - (void)hideInfoWindow;
 - (BOOL)isInfoWindowShown;
 - (void)removeMarker;
-- (UIImage *)clusterMarkerImageWithText:(NSString *)text;
-- (UIImage *)priceMarkerImageWithText:(NSString *)text;
-- (UIImage *)roundedMarkerImageWithText:(NSString *)text;
 @end
 
 @interface FLTMarkersController : NSObject
@@ -45,6 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideMarkerInfoWindowWithIdentifier:(NSString *)identifier result:(FlutterResult)result;
 - (void)isInfoWindowShownForMarkerWithIdentifier:(NSString *)identifier
                                           result:(FlutterResult)result;
+- (UIImage *)clusterMarkerImageWithText:(NSString *)text;
+- (UIImage *)priceMarkerImageWithText:(NSString *)text;
+- (UIImage *)roundedMarkerImageWithText:(NSString *)text;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.h
@@ -5,6 +5,7 @@
 #import <Flutter/Flutter.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import "GoogleMapController.h"
+#import "CozyMarkerBuilder.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(assign, nonatomic, readonly) BOOL consumeTapEvents;
 - (instancetype)initMarkerWithPosition:(CLLocationCoordinate2D)position
                             identifier:(NSString *)identifier
-                               mapView:(GMSMapView *)mapView;
+                               mapView:(GMSMapView *)mapView
+                     cozyMarkerBuilder:(CozyMarkerBuilder *)cozy;
 - (void)showInfoWindow;
 - (void)hideInfoWindow;
 - (BOOL)isInfoWindowShown;
@@ -23,7 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FLTMarkersController : NSObject
 - (instancetype)initWithMethodChannel:(FlutterMethodChannel *)methodChannel
                               mapView:(GMSMapView *)mapView
-                            registrar:(NSObject<FlutterPluginRegistrar> *)registrar;
+                            registrar:(NSObject<FlutterPluginRegistrar> *)registrar
+                            cozyMarkerBuilder:(CozyMarkerBuilder *)cozy;
 - (void)addMarkers:(NSArray *)markersToAdd;
 - (void)changeMarkers:(NSArray *)markersToChange;
 - (void)removeMarkersWithIdentifiers:(NSArray *)identifiers;
@@ -39,9 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideMarkerInfoWindowWithIdentifier:(NSString *)identifier result:(FlutterResult)result;
 - (void)isInfoWindowShownForMarkerWithIdentifier:(NSString *)identifier
                                           result:(FlutterResult)result;
-- (UIImage *)clusterMarkerImageWithText:(NSString *)text;
-- (UIImage *)priceMarkerImageWithText:(NSString *)text;
-- (UIImage *)roundedMarkerImageWithText:(NSString *)text;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -23,21 +23,16 @@
 
 - (instancetype)initMarkerWithPosition:(CLLocationCoordinate2D)position
                             identifier:(NSString *)identifier
-                               mapView:(GMSMapView *)mapView
-                             iconImage:(UIImage *)iconImage
-                              fontPath:(nonnull NSString *)fontPath
-                              markerRadius:(CGFloat)radius {
+                               mapView:(GMSMapView *)mapView {
     self = [super init];
     if (self) {
         _marker = [GMSMarker markerWithPosition:position];
         _mapView = mapView;
         _marker.userData = @[ identifier ];
-        _iconImage = iconImage;
-        _fontPath = fontPath;
-        _markerRadius = radius;
     }
     return self;
 }
+
 
 - (void)showInfoWindow {
     self.mapView.selectedMarker = self.marker;
@@ -102,108 +97,9 @@
     self.marker.zIndex = zIndex;
 }
 
-- (UIImage *)clusterMarkerImageWithText:(NSString *)string {
-    CGSize size = [_iconImage size];
-    UIFont *textFont = [UIFont fontWithName:self.fontPath size:size.width / 2.5];
-    CGSize stringSize = [string sizeWithAttributes:@{NSFontAttributeName:textFont}];
-    CGFloat textY = (size.height / 2) - (stringSize.height / 2);
-    CGFloat textX = (size.width / 2) - (stringSize.width / 2);
-    UIGraphicsBeginImageContext(size);
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
-    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
-        CGRect rect = CGRectMake(0, 0, size.width, size.height);
-        [self.iconImage drawInRect:CGRectIntegral(rect)];
-        CGRect textRect = CGRectMake(textX, textY, stringSize.width, stringSize.height);
-        [string drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
-    }];
-    UIGraphicsEndImageContext();
-    return image;
-}
-
-- (UIImage *)priceMarkerImageWithText:(NSString *)text {
-    UIFont *textFont =  [UIFont fontWithName:self.fontPath size:[_iconImage size].width / 3.5];
-    CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
-    CGFloat markerWidth = stringSize.width * 1.25;
-    CGFloat markerHeight = stringSize.height * 1.50;
-    CGSize canvas = CGSizeMake(markerWidth + 2, markerHeight + 10);
-    CGFloat y = ((canvas.height - 10) / 2) - (stringSize.height / 2);
-    CGFloat x = (canvas.width / 2) - (stringSize.width / 2);
-    CGRect textRect = CGRectMake(x, y, stringSize.width, stringSize.height);
-    UIGraphicsBeginImageContext(canvas);
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
-    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
-        
-        CGMutablePathRef path = CGPathCreateMutable();
-        CGPathMoveToPoint(path, nil, canvas.width / 2 - 10, markerHeight);
-        CGPathAddLineToPoint(path, nil, canvas.width / 2, markerHeight + 10);
-        CGPathAddLineToPoint(path, nil, canvas.width / 2 + 10, markerHeight);
-        CGPathAddLineToPoint(path, nil, canvas.width / 2 - 10, markerHeight);
-        
-        CGContextSetAlpha(rendererContext.CGContext, 0.02);
-        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
-        UIBezierPath *shadow = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth + 2, markerHeight + 2) cornerRadius:5];
-        [shadow fill];
-        [shadow stroke];
-        CGContextSetAlpha(rendererContext.CGContext, 1.0);
-        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
-        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
-        CGContextSetLineWidth(rendererContext.CGContext, 5);
-        CGContextSetLineJoin(rendererContext.CGContext, 0);
-        CGContextAddPath(rendererContext.CGContext, path);
-        CGContextDrawPath(rendererContext.CGContext, 3);
-        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(1, 1, markerWidth, markerHeight) cornerRadius:5];
-        [bezier fill];
-        [bezier stroke];
-        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
-        CGPathRelease(path);
-    }];
-    UIGraphicsEndImageContext();
-    return image;
-}
-
-- (UIImage *)roundedMarkerImageWithText:(NSString *)text {
-    UIFont *textFont =  [UIFont fontWithName:self.fontPath size:[_iconImage size].width / 3.5];
-    CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
-    
-    CGFloat padding = 15;
-    CGFloat shadowSize = 2;
-
-    CGFloat minMarkerWidth = (self.markerRadius / [UIScreen mainScreen].scale) / 2;
-    CGFloat markerWidth = ((stringSize.width > minMarkerWidth) ? stringSize.width : minMarkerWidth) + padding + shadowSize;
-    CGFloat markerHeight = stringSize.height + padding + shadowSize;
-
-    CGSize canvas = CGSizeMake(markerWidth, markerHeight);
-    CGFloat y = (canvas.height / 2) - (stringSize.height / 2);
-    CGFloat x = (canvas.width / 2) - (stringSize.width / 2);
-    CGRect textRect = CGRectMake(x, y, stringSize.width, stringSize.height);
-
-    UIGraphicsBeginImageContext(canvas);
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
-    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
-        
-        CGContextSetAlpha(rendererContext.CGContext, 0.15);
-        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
-        UIBezierPath *shadow = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth, markerHeight) cornerRadius:20];
-        [shadow fill];
-        [shadow stroke];
-        CGContextSetAlpha(rendererContext.CGContext, 1.0);
-        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
-        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
-        CGContextSetLineWidth(rendererContext.CGContext, 5);
-        CGContextSetLineJoin(rendererContext.CGContext, 0);
-        CGContextDrawPath(rendererContext.CGContext, 3);
-        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(shadowSize / 2, shadowSize / 2, markerWidth - shadowSize, markerHeight - shadowSize) cornerRadius:20];
-        [bezier fill];
-        [bezier stroke];
-        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
-    }];
-    UIGraphicsEndImageContext();
-    return image;
-}
-
-
 - (void)interpretMarkerOptions:(NSDictionary *)data
-                     registrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+                     registrar:(NSObject<FlutterPluginRegistrar> *)registrar
+                         image:(UIImage *)image {
     NSNumber *alpha = data[@"alpha"];
     if (alpha && alpha != (id)[NSNull null]) {
         [self setAlpha:[alpha floatValue]];
@@ -216,63 +112,8 @@
     if (draggable && draggable != (id)[NSNull null]) {
         [self setDraggable:[draggable boolValue]];
     }
-    NSString *markerType = data[@"markerType"];
-    if(markerType && markerType != (id)[NSNull null]) {
-        if([markerType isEqualToString:@"icon"]) {
-            NSArray *icon = data[@"icon"];
-            if (icon && icon != (id)[NSNull null]) {
-                UIImage *image = [self extractIconFromData:icon registrar:registrar];
-                [self setIcon:image];
-            }
-        } else if([markerType isEqualToString:@"count"]) {
-            NSString *label = data[@"label"];
-            if(label && label != (id)[NSNull null]) {
-                UIImage *img = [self clusterMarkerImageWithText:label];
-                [self setIcon:img];
-            } else {
-                NSString *error =
-                [NSString stringWithFormat:@"label was not provided."];
-                NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
-                                                                 reason:error
-                                                               userInfo:nil];
-                @throw exception;
-            }
-        } else if([markerType isEqualToString:@"rounded"]) {
-            NSString *label = data[@"label"];
-            if(label && label != (id)[NSNull null]) {
-                UIImage *img = [self roundedMarkerImageWithText:label];
-                [self setIcon:img];
-            } else {
-                NSString *error =
-                [NSString stringWithFormat:@"label was not provided."];
-                NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
-                                                                 reason:error
-                                                               userInfo:nil];
-                @throw exception;
-            }           
-         }
-        else if([markerType isEqualToString:@"price"]) {
-            NSString *label = data[@"label"];
-            if(label && label != (id)[NSNull null]) {
-                UIImage *img = [self priceMarkerImageWithText:label];
-                [self setIcon:img];
-            } else {
-                NSString *error =
-                [NSString stringWithFormat:@"label was not provided."];
-                NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
-                                                                 reason:error
-                                                               userInfo:nil];
-                @throw exception;
-            }            }
-        else {
-            NSString *error =
-            [NSString stringWithFormat:@"MarkerType was not provided."];
-            NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
-                                                             reason:error
-                                                           userInfo:nil];
-            @throw exception;
-        }
-        
+    if(image && image != (id)[NSNull null]) {
+        [self setIcon:image];
     }
     NSNumber *flat = data[@"flat"];
     if (flat && flat != (id)[NSNull null]) {
@@ -316,79 +157,12 @@
     }
 }
 
-- (UIImage *)extractIconFromData:(NSArray *)iconData
-                       registrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-    UIImage *image;
-    if ([iconData.firstObject isEqualToString:@"defaultMarker"]) {
-        CGFloat hue = (iconData.count == 1) ? 0.0f : [iconData[1] doubleValue];
-        image = [GMSMarker markerImageWithColor:[UIColor colorWithHue:hue / 360.0
-                                                           saturation:1.0
-                                                           brightness:0.7
-                                                                alpha:1.0]];
-    } else if ([iconData.firstObject isEqualToString:@"fromAsset"]) {
-        if (iconData.count == 2) {
-            image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
-        } else {
-            image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]
-                                                         fromPackage:iconData[2]]];
-        }
-    } else if ([iconData.firstObject isEqualToString:@"fromAssetImage"]) {
-        if (iconData.count == 3) {
-            image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
-            id scaleParam = iconData[2];
-            image = [self scaleImage:image by:scaleParam];
-        } else {
-            NSString *error =
-            [NSString stringWithFormat:@"'fromAssetImage' should have exactly 3 arguments. Got: %lu",
-             (unsigned long)iconData.count];
-            NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
-                                                             reason:error
-                                                           userInfo:nil];
-            @throw exception;
-        }
-    } else if ([iconData[0] isEqualToString:@"fromBytes"]) {
-        if (iconData.count == 2) {
-            @try {
-                FlutterStandardTypedData *byteData = iconData[1];
-                CGFloat screenScale = [[UIScreen mainScreen] scale];
-                image = [UIImage imageWithData:[byteData data] scale:screenScale];
-            } @catch (NSException *exception) {
-                @throw [NSException exceptionWithName:@"InvalidByteDescriptor"
-                                               reason:@"Unable to interpret bytes as a valid image."
-                                             userInfo:nil];
-            }
-        } else {
-            NSString *error = [NSString
-                               stringWithFormat:@"fromBytes should have exactly one argument, the bytes. Got: %lu",
-                               (unsigned long)iconData.count];
-            NSException *exception = [NSException exceptionWithName:@"InvalidByteDescriptor"
-                                                             reason:error
-                                                           userInfo:nil];
-            @throw exception;
-        }
-    }
-    
-    return image;
-}
-
-- (UIImage *)scaleImage:(UIImage *)image by:(id)scaleParam {
-    double scale = 1.0;
-    if ([scaleParam isKindOfClass:[NSNumber class]]) {
-        scale = [scaleParam doubleValue];
-    }
-    if (fabs(scale - 1) > 1e-3) {
-        return [UIImage imageWithCGImage:[image CGImage]
-                                   scale:(image.scale * scale)
-                             orientation:(image.imageOrientation)];
-    }
-    return image;
-}
-
 @end
 
 @interface FLTMarkersController ()
 
 @property(strong, nonatomic) NSMutableDictionary *markerIdentifierToController;
+@property(strong, nonatomic) NSCache *cache;
 @property(strong, nonatomic) FlutterMethodChannel *methodChannel;
 @property(strong, nonatomic) UIImage *emptyClusterMarker;
 @property(strong, nonatomic) NSString *fontPath;
@@ -400,6 +174,7 @@
 
 @implementation FLTMarkersController
 
+
 - (instancetype)initWithMethodChannel:(FlutterMethodChannel *)methodChannel
                               mapView:(GMSMapView *)mapView
                             registrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -408,6 +183,7 @@
         _methodChannel = methodChannel;
         _mapView = mapView;
         _markerIdentifierToController = [[NSMutableDictionary alloc] init];
+        _cache = [[NSCache alloc] init];
         _registrar = registrar;
         _emptyClusterMarker = [self baseClusterMarker];
         _fontPath = [self loadFont];
@@ -488,6 +264,173 @@ void CFSafeRelease(CFTypeRef cf) {
     return image;
 }
 
+- (UIImage *)clusterMarkerImageWithText:(NSString *)string {
+    CGSize size = [self.baseClusterMarker size];
+    UIFont *textFont = [UIFont fontWithName:self.fontPath size:size.width / 2.5];
+    CGSize stringSize = [string sizeWithAttributes:@{NSFontAttributeName:textFont}];
+    CGFloat textY = (size.height / 2) - (stringSize.height / 2);
+    CGFloat textX = (size.width / 2) - (stringSize.width / 2);
+    UIGraphicsBeginImageContext(size);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        CGRect rect = CGRectMake(0, 0, size.width, size.height);
+        [self.baseClusterMarker drawInRect:CGRectIntegral(rect)];
+        CGRect textRect = CGRectMake(textX, textY, stringSize.width, stringSize.height);
+        [string drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)priceMarkerImageWithText:(NSString *)text {
+    UIFont *textFont =  [UIFont fontWithName:self.fontPath size:[self.baseClusterMarker size].width / 3.5];
+    CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
+    CGFloat markerWidth = stringSize.width * 1.25;
+    CGFloat markerHeight = stringSize.height * 1.50;
+    CGSize canvas = CGSizeMake(markerWidth + 2, markerHeight + 10);
+    CGFloat y = ((canvas.height - 10) / 2) - (stringSize.height / 2);
+    CGFloat x = (canvas.width / 2) - (stringSize.width / 2);
+    CGRect textRect = CGRectMake(x, y, stringSize.width, stringSize.height);
+    UIGraphicsBeginImageContext(canvas);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        
+        CGMutablePathRef path = CGPathCreateMutable();
+        CGPathMoveToPoint(path, nil, canvas.width / 2 - 10, markerHeight);
+        CGPathAddLineToPoint(path, nil, canvas.width / 2, markerHeight + 10);
+        CGPathAddLineToPoint(path, nil, canvas.width / 2 + 10, markerHeight);
+        CGPathAddLineToPoint(path, nil, canvas.width / 2 - 10, markerHeight);
+        
+        CGContextSetAlpha(rendererContext.CGContext, 0.02);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
+        UIBezierPath *shadow = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth + 2, markerHeight + 2) cornerRadius:5];
+        [shadow fill];
+        [shadow stroke];
+        CGContextSetAlpha(rendererContext.CGContext, 1.0);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
+        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
+        CGContextSetLineWidth(rendererContext.CGContext, 5);
+        CGContextSetLineJoin(rendererContext.CGContext, 0);
+        CGContextAddPath(rendererContext.CGContext, path);
+        CGContextDrawPath(rendererContext.CGContext, 3);
+        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(1, 1, markerWidth, markerHeight) cornerRadius:5];
+        [bezier fill];
+        [bezier stroke];
+        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
+        CGPathRelease(path);
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)roundedMarkerImageWithText:(NSString *)text {
+    UIFont *textFont =  [UIFont fontWithName:self.fontPath size:[self.baseClusterMarker size].width / 3.5];
+    CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
+    
+    CGFloat padding = 15;
+    CGFloat shadowSize = 2;
+
+    CGFloat minMarkerWidth = (self.markerRadius / [UIScreen mainScreen].scale) / 2;
+    CGFloat markerWidth = ((stringSize.width > minMarkerWidth) ? stringSize.width : minMarkerWidth) + padding + shadowSize;
+    CGFloat markerHeight = stringSize.height + padding + shadowSize;
+
+    CGSize canvas = CGSizeMake(markerWidth, markerHeight);
+    CGFloat y = (canvas.height / 2) - (stringSize.height / 2);
+    CGFloat x = (canvas.width / 2) - (stringSize.width / 2);
+    CGRect textRect = CGRectMake(x, y, stringSize.width, stringSize.height);
+
+    UIGraphicsBeginImageContext(canvas);
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        
+        CGContextSetAlpha(rendererContext.CGContext, 0.15);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.grayColor.CGColor);
+        UIBezierPath *shadow = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth, markerHeight) cornerRadius:20];
+        [shadow fill];
+        [shadow stroke];
+        CGContextSetAlpha(rendererContext.CGContext, 1.0);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.whiteColor.CGColor);
+        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
+        CGContextSetLineWidth(rendererContext.CGContext, 5);
+        CGContextSetLineJoin(rendererContext.CGContext, 0);
+        CGContextDrawPath(rendererContext.CGContext, 3);
+        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(shadowSize / 2, shadowSize / 2, markerWidth - shadowSize, markerHeight - shadowSize) cornerRadius:20];
+        [bezier fill];
+        [bezier stroke];
+        [text drawInRect:CGRectIntegral(textRect) withAttributes:@{NSFontAttributeName:textFont}];
+    }];
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+- (UIImage *)extractIconFromData:(NSArray *)iconData
+                       registrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+    UIImage *image;
+    if ([iconData.firstObject isEqualToString:@"defaultMarker"]) {
+        CGFloat hue = (iconData.count == 1) ? 0.0f : [iconData[1] doubleValue];
+        image = [GMSMarker markerImageWithColor:[UIColor colorWithHue:hue / 360.0
+                                                           saturation:1.0
+                                                           brightness:0.7
+                                                                alpha:1.0]];
+    } else if ([iconData.firstObject isEqualToString:@"fromAsset"]) {
+        if (iconData.count == 2) {
+            image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
+        } else {
+            image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]
+                                                         fromPackage:iconData[2]]];
+        }
+    } else if ([iconData.firstObject isEqualToString:@"fromAssetImage"]) {
+        if (iconData.count == 3) {
+            image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
+            id scaleParam = iconData[2];
+            image = [self scaleImage:image by:scaleParam];
+        } else {
+            NSString *error =
+            [NSString stringWithFormat:@"'fromAssetImage' should have exactly 3 arguments. Got: %lu",
+             (unsigned long)iconData.count];
+            NSException *exception = [NSException exceptionWithName:@"InvalidBitmapDescriptor"
+                                                             reason:error
+                                                           userInfo:nil];
+            @throw exception;
+        }
+    } else if ([iconData[0] isEqualToString:@"fromBytes"]) {
+        if (iconData.count == 2) {
+            @try {
+                FlutterStandardTypedData *byteData = iconData[1];
+                CGFloat screenScale = [[UIScreen mainScreen] scale];
+                image = [UIImage imageWithData:[byteData data] scale:screenScale];
+            } @catch (NSException *exception) {
+                @throw [NSException exceptionWithName:@"InvalidByteDescriptor"
+                                               reason:@"Unable to interpret bytes as a valid image."
+                                             userInfo:nil];
+            }
+        } else {
+            NSString *error = [NSString
+                               stringWithFormat:@"fromBytes should have exactly one argument, the bytes. Got: %lu",
+                               (unsigned long)iconData.count];
+            NSException *exception = [NSException exceptionWithName:@"InvalidByteDescriptor"
+                                                             reason:error
+                                                           userInfo:nil];
+            @throw exception;
+        }
+    }
+    
+    return image;
+}
+
+- (UIImage *)scaleImage:(UIImage *)image by:(id)scaleParam {
+    double scale = 1.0;
+    if ([scaleParam isKindOfClass:[NSNumber class]]) {
+        scale = [scaleParam doubleValue];
+    }
+    if (fabs(scale - 1) > 1e-3) {
+        return [UIImage imageWithCGImage:[image CGImage]
+                                   scale:(image.scale * scale)
+                             orientation:(image.imageOrientation)];
+    }
+    return image;
+}
+
 - (void)addMarkers:(NSArray *)markersToAdd {
     for (NSDictionary *marker in markersToAdd) {
         CLLocationCoordinate2D position = [FLTMarkersController getPosition:marker];
@@ -495,13 +438,55 @@ void CFSafeRelease(CFTypeRef cf) {
         FLTGoogleMapMarkerController *controller =
         [[FLTGoogleMapMarkerController alloc] initMarkerWithPosition:position
                                                           identifier:identifier
-                                                             mapView:self.mapView
-                                                           iconImage:self.emptyClusterMarker
-                                                            fontPath:self.fontPath
-                                                            markerRadius:[self markerRadius]];
-        [controller interpretMarkerOptions:marker registrar:self.registrar];
+                                                             mapView:self.mapView];
+        
+        UIImage *image = [self getMarkerImage:marker];
+        [controller interpretMarkerOptions:marker registrar:self.registrar image:image];
+        
         self.markerIdentifierToController[identifier] = controller;
     }
+}
+
+-(UIImage *)getMarkerImage:(NSDictionary *)marker {
+    NSString *markerType = marker[@"markerType"];
+    if(markerType == (id)[NSNull null] || [markerType isEqualToString:@""]) {
+        @throw [NSException exceptionWithName:@"InvalidMarker"
+                                       reason:@"no markerType was provided."
+                                     userInfo:nil];;
+    }
+    if([markerType isEqualToString:@"icon"]) {
+        if (marker[@"icon"] == (id)[NSNull null]) {
+            @throw [NSException exceptionWithName:@"InvalidMarker"
+                                           reason:@"markerType was icon, but icon was not provided."
+                                         userInfo:nil];
+        }
+        return [self extractIconFromData:marker[@"icon"] registrar:self.registrar];
+    }
+    NSString *label = marker[@"label"];
+    if(label == (id)[NSNull null] || [label isEqualToString:@""]) {
+        @throw [NSException exceptionWithName:@"InvalidMarker"
+                                       reason:@"no label was provided when expected."
+                                     userInfo:nil];
+    }
+    UIImage *cachedImage = [[self cache] objectForKey:label];
+    if(cachedImage != (id)[NSNull null]) {
+        return cachedImage;
+    }
+    UIImage *image;
+    if([markerType isEqualToString:@"rounded"]) {
+        image = [self roundedMarkerImageWithText:label];
+    }
+    else if([markerType isEqualToString:@"count"]) {
+        image = [self clusterMarkerImageWithText:label];
+    }
+    else if([markerType isEqualToString:@"price"]) {
+        image = [self priceMarkerImageWithText:label];
+    } else {
+        @throw [NSException exceptionWithName:@"InvalidMarker"
+                                       reason:@"invalid markerType!"
+                                     userInfo:nil];
+    }
+    return image;
 }
 
 - (void)changeMarkers:(NSArray *)markersToChange {
@@ -511,7 +496,8 @@ void CFSafeRelease(CFTypeRef cf) {
         if (!controller) {
             continue;
         }
-        [controller interpretMarkerOptions:marker registrar:self.registrar];
+        UIImage *image = [self getMarkerImage:marker];
+        [controller interpretMarkerOptions:marker registrar:self.registrar image:image];
     }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -468,7 +468,8 @@ void CFSafeRelease(CFTypeRef cf) {
                                        reason:@"no label was provided when expected."
                                      userInfo:nil];
     }
-    UIImage *cachedImage = [[self cache] objectForKey:label];
+    NSString *key = [NSString stringWithFormat:@"%@:%@", markerType, label];
+    UIImage *cachedImage = [[self cache] objectForKey:key];
     if(cachedImage != nil) {
         return cachedImage;
     }
@@ -486,7 +487,7 @@ void CFSafeRelease(CFTypeRef cf) {
                                        reason:@"invalid markerType!"
                                      userInfo:nil];
     }
-    [[self cache] setObject:image forKey:label];
+    [[self cache] setObject:image forKey:key];
     return image;
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -469,7 +469,7 @@ void CFSafeRelease(CFTypeRef cf) {
                                      userInfo:nil];
     }
     UIImage *cachedImage = [[self cache] objectForKey:label];
-    if(cachedImage != (id)[NSNull null]) {
+    if(cachedImage != nil) {
         return cachedImage;
     }
     UIImage *image;
@@ -486,6 +486,7 @@ void CFSafeRelease(CFTypeRef cf) {
                                        reason:@"invalid markerType!"
                                      userInfo:nil];
     }
+    [[self cache] setObject:image forKey:label];
     return image;
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -583,6 +583,7 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
 Map<String, Object> _jsonForMapConfiguration(MapConfiguration config) {
   final EdgeInsets? padding = config.padding;
   return <String, Object>{
+    if (config.cacheMarkers != null) 'cacheMarkers': config.cacheMarkers!,
     if (config.compassEnabled != null) 'compassEnabled': config.compassEnabled!,
     if (config.mapToolbarEnabled != null)
       'mapToolbarEnabled': config.mapToolbarEnabled!,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -583,7 +583,8 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
 Map<String, Object> _jsonForMapConfiguration(MapConfiguration config) {
   final EdgeInsets? padding = config.padding;
   return <String, Object>{
-    if (config.cacheMarkers != null) 'cacheMarkers': config.cacheMarkers!,
+    if (config.enableMarkerCaching != null)
+      'enableMarkerCaching': config.enableMarkerCaching!,
     if (config.compassEnabled != null) 'compassEnabled': config.compassEnabled!,
     if (config.mapToolbarEnabled != null)
       'mapToolbarEnabled': config.mapToolbarEnabled!,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
@@ -15,7 +15,7 @@ class MapConfiguration {
   /// as either a full configuration selection, or an update to an existing
   /// configuration where only non-null values are updated.
   const MapConfiguration({
-    this.cacheMarkers,
+    this.enableMarkerCaching,
     this.compassEnabled,
     this.mapToolbarEnabled,
     this.cameraTargetBounds,
@@ -52,7 +52,7 @@ class MapConfiguration {
   final MinMaxZoomPreference? minMaxZoomPreference;
 
   /// True if map should cache markers.
-  final bool? cacheMarkers;
+  final bool? enableMarkerCaching;
 
   /// True if rotate gestures should be enabled.
   final bool? rotateGesturesEnabled;
@@ -98,7 +98,9 @@ class MapConfiguration {
   /// that are different from [other].
   MapConfiguration diffFrom(MapConfiguration other) {
     return MapConfiguration(
-      cacheMarkers: cacheMarkers != other.cacheMarkers ? cacheMarkers : null,
+      enableMarkerCaching: enableMarkerCaching != other.enableMarkerCaching
+          ? enableMarkerCaching
+          : null,
       compassEnabled:
           compassEnabled != other.compassEnabled ? compassEnabled : null,
       mapToolbarEnabled: mapToolbarEnabled != other.mapToolbarEnabled
@@ -155,7 +157,9 @@ class MapConfiguration {
   /// replacing the previous values.
   MapConfiguration applyDiff(MapConfiguration diff) {
     return MapConfiguration(
-      cacheMarkers: cacheMarkers != diff.cacheMarkers ? cacheMarkers : null,
+      enableMarkerCaching: enableMarkerCaching != diff.enableMarkerCaching
+          ? enableMarkerCaching
+          : null,
       compassEnabled: diff.compassEnabled ?? compassEnabled,
       mapToolbarEnabled: diff.mapToolbarEnabled ?? mapToolbarEnabled,
       cameraTargetBounds: diff.cameraTargetBounds ?? cameraTargetBounds,
@@ -219,7 +223,7 @@ class MapConfiguration {
         scrollGesturesEnabled == other.scrollGesturesEnabled &&
         tiltGesturesEnabled == other.tiltGesturesEnabled &&
         trackCameraPosition == other.trackCameraPosition &&
-        cacheMarkers == other.cacheMarkers &&
+        enableMarkerCaching == other.enableMarkerCaching &&
         zoomControlsEnabled == other.zoomControlsEnabled &&
         zoomGesturesEnabled == other.zoomGesturesEnabled &&
         liteModeEnabled == other.liteModeEnabled &&
@@ -238,7 +242,7 @@ class MapConfiguration {
         cameraTargetBounds,
         mapType,
         minMaxZoomPreference,
-        cacheMarkers,
+        enableMarkerCaching,
         rotateGesturesEnabled,
         scrollGesturesEnabled,
         tiltGesturesEnabled,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
@@ -15,6 +15,7 @@ class MapConfiguration {
   /// as either a full configuration selection, or an update to an existing
   /// configuration where only non-null values are updated.
   const MapConfiguration({
+    this.cacheMarkers,
     this.compassEnabled,
     this.mapToolbarEnabled,
     this.cameraTargetBounds,
@@ -49,6 +50,9 @@ class MapConfiguration {
 
   /// The prefered zoom range.
   final MinMaxZoomPreference? minMaxZoomPreference;
+
+  /// True if map should cache markers.
+  final bool? cacheMarkers;
 
   /// True if rotate gestures should be enabled.
   final bool? rotateGesturesEnabled;
@@ -94,6 +98,7 @@ class MapConfiguration {
   /// that are different from [other].
   MapConfiguration diffFrom(MapConfiguration other) {
     return MapConfiguration(
+      cacheMarkers: cacheMarkers != other.cacheMarkers ? cacheMarkers : null,
       compassEnabled:
           compassEnabled != other.compassEnabled ? compassEnabled : null,
       mapToolbarEnabled: mapToolbarEnabled != other.mapToolbarEnabled
@@ -150,6 +155,7 @@ class MapConfiguration {
   /// replacing the previous values.
   MapConfiguration applyDiff(MapConfiguration diff) {
     return MapConfiguration(
+      cacheMarkers: cacheMarkers != diff.cacheMarkers ? cacheMarkers : null,
       compassEnabled: diff.compassEnabled ?? compassEnabled,
       mapToolbarEnabled: diff.mapToolbarEnabled ?? mapToolbarEnabled,
       cameraTargetBounds: diff.cameraTargetBounds ?? cameraTargetBounds,
@@ -213,6 +219,7 @@ class MapConfiguration {
         scrollGesturesEnabled == other.scrollGesturesEnabled &&
         tiltGesturesEnabled == other.tiltGesturesEnabled &&
         trackCameraPosition == other.trackCameraPosition &&
+        cacheMarkers == other.cacheMarkers &&
         zoomControlsEnabled == other.zoomControlsEnabled &&
         zoomGesturesEnabled == other.zoomGesturesEnabled &&
         liteModeEnabled == other.liteModeEnabled &&
@@ -231,6 +238,7 @@ class MapConfiguration {
         cameraTargetBounds,
         mapType,
         minMaxZoomPreference,
+        cacheMarkers,
         rotateGesturesEnabled,
         scrollGesturesEnabled,
         tiltGesturesEnabled,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/utils/map_configuration_serialization.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/utils/map_configuration_serialization.dart
@@ -20,7 +20,8 @@ import '../map_configuration.dart';
 Map<String, Object> jsonForMapConfiguration(MapConfiguration config) {
   final EdgeInsets? padding = config.padding;
   return <String, Object>{
-    if (config.cacheMarkers != null) 'cacheMarkers': config.cacheMarkers!,
+    if (config.enableMarkerCaching != null)
+      'enableMarkerCaching': config.enableMarkerCaching!,
     if (config.compassEnabled != null) 'compassEnabled': config.compassEnabled!,
     if (config.mapToolbarEnabled != null)
       'mapToolbarEnabled': config.mapToolbarEnabled!,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/utils/map_configuration_serialization.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/utils/map_configuration_serialization.dart
@@ -20,6 +20,7 @@ import '../map_configuration.dart';
 Map<String, Object> jsonForMapConfiguration(MapConfiguration config) {
   final EdgeInsets? padding = config.padding;
   return <String, Object>{
+    if (config.cacheMarkers != null) 'cacheMarkers': config.cacheMarkers!,
     if (config.compassEnabled != null) 'compassEnabled': config.compassEnabled!,
     if (config.mapToolbarEnabled != null)
       'mapToolbarEnabled': config.mapToolbarEnabled!,

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5.1
+      ref: v2.2.1-fork.6
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.5
+      ref: v2.2.1-fork.5.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0


### PR DESCRIPTION
**This PR sets memory caching to reuse markers on runtime to avoid rendering markers that already have been rendered.**

### **How does it work?** 
---

It does so by applying a logic that if a marker was not rendered before, it will be rendered, then stored in a caching store.
Then, whenever a new search finds a marker with a same label (be it in the same location or in another), it will fetch the marker in the cache store and use it without the need to render it again.

At start it will only store markers, as none is stored in cache yet. But by navigating and exploring the map, when a cluster/price/rounded marker that has been rendered before, it will recover it from cache.

The print below show markers being added and recovered in the console:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/109806620/219446916-3b7ab757-8296-47a4-8b2a-fb72bc3aa3bf.png">

**Please note that this PR is not supposed to merge with the target branch. As soon as this PR is approved a new tag will be created from this branch and the new tag will be used by the app to keep the main branch intact for now.**
