### PR TITLE
feat(TA-2492): new price pins

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -424,10 +424,13 @@ class Convert {
         sink.setIcon(toBitmapDescriptor(icon));
         break;
       case "price":
-      case "rounded":
-      case "rounded_selected":
-      case "rounded_visited":
-      case "count":
+      case "cluster":
+      case "pin_cluster":
+      case "pin_cluster_visited":
+      case "pin_cluster_selected":
+      case "pin_price":
+      case "pin_price_visited":
+      case "pin_price_selected":
         final Object label = data.get("label");
         if (label == null) {
           throw new IllegalArgumentException("markerType was label but label was not provided.");

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -7,6 +7,8 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Typeface;
@@ -14,7 +16,7 @@ import android.graphics.Typeface;
 import androidx.core.content.res.ResourcesCompat;
 
 public class CozyMarkerBuilder {
-    private final int shadowSize = 3;
+    private final int shadowSize = 4;
     private final int priceMarkerTailSize;
     private final int padding;
     private final int size;
@@ -45,11 +47,12 @@ public class CozyMarkerBuilder {
         return paint;
     }
 
-    private Paint getShadowPaint() {
+    private Paint getShadowPaint(int alpha) {
         Paint paint = new Paint();
         paint.setColor(Color.BLACK);
+        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OVER));
         paint.setStyle(Paint.Style.STROKE);
-        paint.setAlpha(15);
+        paint.setAlpha(alpha);
         paint.setStrokeWidth(shadowSize);
         paint.setAntiAlias(true);
         return paint;
@@ -71,10 +74,18 @@ public class CozyMarkerBuilder {
             return Math.max(proportionalMarkerSize, minMarkerSize);
     }
 
-    private Bitmap getClusterMarkerBitmap(String text) {
+    private float getTextYOffset(float markerHeight, Rect rect) {
+        return (markerHeight / 2f) + (rect.height() / 2f) - rect.bottom;
+    }
+
+    private float getTextXOffset(float markerWidth, Rect rect) {
+        return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
+    }
+
+    private Bitmap getClusterBitmap(String text) {
         Bitmap marker = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(marker);
-        canvas.drawCircle(size / 2f, size / 2f, size / 2.2f, getShadowPaint());
+        canvas.drawCircle(size / 2f, size / 2f, size / 2.2f, getShadowPaint(15));
         canvas.drawCircle(size / 2f, size / 2f, (size / 2.2f) - shadowSize, getMarkerPaint(Color.WHITE));
         Rect clusterRect = new Rect();
         Paint clusterTextStyle = getTextPaint(size / 3f, Color.BLACK);
@@ -85,20 +96,20 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    private Path getPriceMarkerTail(Bitmap marker) {
+    private Path addTailOnMarkerCenter(Bitmap marker, int tailSize) {
         Path pointer = new Path();
         pointer.setFillType(Path.FillType.EVEN_ODD);
         float width = marker.getWidth();
-        float height = marker.getHeight() - priceMarkerTailSize - shadowSize;
-        pointer.moveTo(width / 2f - priceMarkerTailSize, height);
-        pointer.lineTo(width / 2f + priceMarkerTailSize, height);
-        pointer.lineTo(width / 2f, height + priceMarkerTailSize);
-        pointer.lineTo(width / 2f - priceMarkerTailSize, height);
+        float height = marker.getHeight() - tailSize - shadowSize;
+        pointer.moveTo(width / 2f - tailSize, height);
+        pointer.lineTo(width / 2f + tailSize, height);
+        pointer.lineTo(width / 2f, height + tailSize);
+        pointer.lineTo(width / 2f - tailSize, height);
         pointer.close();
         return pointer;
     }
 
-    private Bitmap getPriceMarkerBitmap(String text) {
+    private Bitmap getPriceBitmap(String text) {
         Rect rect = new Rect();
         Paint priceMarkerTextStyle = getTextPaint(size / 3.5f, Color.BLACK);
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
@@ -115,9 +126,9 @@ public class CozyMarkerBuilder {
         Canvas canvas = new Canvas(marker);
 
         int borderRadius = 20;
-        canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint());
+        canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint(15));
         canvas.drawRoundRect(bubble, borderRadius, borderRadius, getMarkerPaint(Color.WHITE));
-        canvas.drawPath(getPriceMarkerTail(marker), getMarkerPaint(Color.WHITE));
+        canvas.drawPath(addTailOnMarkerCenter(marker, priceMarkerTailSize), getMarkerPaint(Color.WHITE));
 
         float dx = getTextXOffset(width, rect);
         float dy = getTextYOffset(height, rect);
@@ -125,34 +136,42 @@ public class CozyMarkerBuilder {
         return marker;
     }
 
-    private float getTextYOffset(float markerHeight, Rect rect) {
-        return (markerHeight / 2f) + (rect.height() / 2f) - rect.bottom;
-    }
+    private Bitmap getPinBitmap(String text, int markerColor, int textColor, boolean hasTail) {
 
-    private float getTextXOffset(float markerWidth, Rect rect) {
-        return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
-    }
-
-    private Bitmap getRoundedMarkerBitmap(String text, int markerColor, int textColor) {
+        float textSize = size / 4f;
         Rect rect = new Rect();
-        Paint priceMarkerTextStyle = getTextPaint(size / 3.5f, textColor);
+        Paint priceMarkerTextStyle = getTextPaint(textSize, textColor);
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
-        int minWidth = Math.max(rect.width(), size / 2);
 
+        int smallestPinSize = size / 2;
+        int minWidth = Math.max(rect.width(), smallestPinSize);
         int markerWidth = minWidth + padding + shadowSize;
+
+        int priceTailSize = (hasTail ? (int) (priceMarkerTailSize / 1.5f) : 0);
         int markerHeight = rect.height() + padding + shadowSize;
-        Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight, Bitmap.Config.ARGB_8888);
 
+        Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight + priceTailSize, Bitmap.Config.ARGB_8888);
+
+        int shapeWidth = markerWidth - shadowSize;
+        int shapeHeight = markerHeight - shadowSize;
         RectF shadow = new RectF(0, 0, markerWidth, markerHeight);
-        RectF shape = new RectF(shadowSize, shadowSize, markerWidth - shadowSize, markerHeight - shadowSize);
+        RectF shape = new RectF(shadowSize, shadowSize, shapeWidth, shapeHeight);
 
-        int borderRadius = 40;
+        int shadowBorderRadius = 40;
+        int shapeBorderRadius = 50;
         Canvas canvas = new Canvas(marker);
-        canvas.drawRoundRect(shadow, borderRadius, borderRadius, getShadowPaint());
-        canvas.drawRoundRect(shape, borderRadius, borderRadius, getMarkerPaint(markerColor));
+        canvas.drawRoundRect(shadow, shadowBorderRadius, shadowBorderRadius, getShadowPaint(25));
+        canvas.drawRoundRect(shape, shapeBorderRadius, shapeBorderRadius, getMarkerPaint(markerColor));
+
+        if (hasTail) {
+            int shadowTailSize = priceTailSize + shadowSize;
+            canvas.drawPath(addTailOnMarkerCenter(marker, shadowTailSize), getShadowPaint(25));
+            canvas.drawPath(addTailOnMarkerCenter(marker, priceTailSize),
+                    getMarkerPaint(markerColor));
+        }
 
         float dx = getTextXOffset(markerWidth, rect);
-        float dy = getTextYOffset(markerHeight, rect);
+        float dy = getTextYOffset(shapeHeight, rect);
 
         canvas.drawText(text, dx, dy, priceMarkerTextStyle);
         return marker;
@@ -160,23 +179,30 @@ public class CozyMarkerBuilder {
 
     private Bitmap getMarker(String type, String text) {
         switch (type) {
-            case "count":
-                return getClusterMarkerBitmap(text);
+            case "cluster":
+                return getClusterBitmap(text);
             case "price":
-                return getPriceMarkerBitmap(text);
-            case "rounded":
-                return getRoundedMarkerBitmap(text, Color.WHITE, Color.BLACK);
-            case "rounded_selected":
-                return getRoundedMarkerBitmap(text, Color.rgb(57, 87, 189), Color.WHITE);
-            case "rounded_visited":
-                return getRoundedMarkerBitmap(text, Color.WHITE, Color.rgb(110, 110, 100));
+                return getPriceBitmap(text);
+            case "pin_cluster":
+                return getPinBitmap(text, Color.WHITE, Color.BLACK, false);
+            case "pin_cluster_selected":
+                return getPinBitmap(text, Color.rgb(57, 87, 189), Color.WHITE, false);
+            case "pin_cluster_visited":
+                return getPinBitmap(text, Color.WHITE, Color.rgb(110, 110, 100), false);
+            case "pin_price":
+                return getPinBitmap(text, Color.WHITE, Color.BLACK, true);
+            case "pin_price_selected":
+                return getPinBitmap(text, Color.rgb(57, 87, 189), Color.WHITE, true);
+            case "pin_price_visited":
+                return getPinBitmap(text, Color.WHITE, Color.rgb(110, 110, 100), true);
             default:
                 return null;
         }
     }
 
     private Bitmap copyOnlyBitmapProperties(Bitmap bitmap) {
-        if (bitmap == null) return null;
+        if (bitmap == null)
+            return null;
         return bitmap.copy(bitmap.getConfig(), true);
     }
 
@@ -196,7 +222,7 @@ public class CozyMarkerBuilder {
     }
 
     public Bitmap buildMarker(String type, String text) {
-        if(markerCache != null) {
+        if (markerCache != null) {
             final Bitmap marker = bitmapWithCache(type, text);
             return copyOnlyBitmapProperties(marker);
         }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -138,7 +138,7 @@ public class CozyMarkerBuilder {
 
     private Bitmap getPinBitmap(String text, int markerColor, int textColor, boolean hasTail) {
 
-        float textSize = size / 4f;
+        float textSize = size / 3.5f;
         Rect rect = new Rect();
         Paint priceMarkerTextStyle = getTextPaint(textSize, textColor);
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
@@ -154,21 +154,27 @@ public class CozyMarkerBuilder {
 
         int shapeWidth = markerWidth - shadowSize;
         int shapeHeight = markerHeight - shadowSize;
-        RectF shadow = new RectF(0, 0, markerWidth, markerHeight);
-        RectF shape = new RectF(shadowSize, shadowSize, shapeWidth, shapeHeight);
 
-        int shadowBorderRadius = 40;
+        RectF shape = new RectF(shadowSize, shadowSize, shapeWidth, shapeHeight);
+        Path bubblePath = new Path();
         int shapeBorderRadius = 50;
+        bubblePath.addRoundRect(shape, shapeBorderRadius, shapeBorderRadius, Path.Direction.CW);
+
         Canvas canvas = new Canvas(marker);
-        canvas.drawRoundRect(shadow, shadowBorderRadius, shadowBorderRadius, getShadowPaint(25));
-        canvas.drawRoundRect(shape, shapeBorderRadius, shapeBorderRadius, getMarkerPaint(markerColor));
 
         if (hasTail) {
-            int shadowTailSize = priceTailSize + shadowSize;
-            canvas.drawPath(addTailOnMarkerCenter(marker, shadowTailSize), getShadowPaint(25));
-            canvas.drawPath(addTailOnMarkerCenter(marker, priceTailSize),
-                    getMarkerPaint(markerColor));
+            bubblePath.addPath(addTailOnMarkerCenter(marker, priceTailSize));
         }
+
+        Paint paint = new Paint();
+        paint.setAntiAlias(true);
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setStrokeWidth(shadowSize);
+        paint.setAlpha(50);
+        paint.setShadowLayer(shadowSize, 0, 0, Color.BLACK);
+        paint.setStyle(Paint.Style.FILL);
+        paint.setColor(markerColor);
+        canvas.drawPath(bubblePath, paint);
 
         float dx = getTextXOffset(markerWidth, rect);
         float dy = getTextYOffset(shapeHeight, rect);

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -200,13 +200,13 @@ void CFSafeRelease(CFTypeRef cf) {
         CGContextSetLineJoin(rendererContext.CGContext, 0);
         
         // drawing bubble from point x/y, and with width and height
-        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, markerWidth, markerHeight - tailSize) cornerRadius:20];
+        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(shadowWidth / 2, shadowWidth / 2, markerWidth - shadowWidth, markerHeight - shadowWidth - tailSize) cornerRadius:20];
         
         // if a tail will be used, sets a point in the bottom center of the bubble,
         // draws a triangle from this point and adds to the bubble path above
         if(withTail) {
             CGFloat x = canvas.width / 2;
-            CGFloat y = markerHeight - tailSize;
+            CGFloat y = markerHeight - tailSize - shadowWidth / 2;
             
             UIBezierPath *tailPath = [UIBezierPath bezierPath];
             [tailPath moveToPoint:CGPointMake(x - tailSize, y)];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -164,7 +164,7 @@ void CFSafeRelease(CFTypeRef cf) {
 
 - (UIImage *)pinMarkerImageWithText:(NSString *)text withMarkerColor:(UIColor *)color withTextColor:(UIColor *)textColor withTail:(BOOL)withTail {
     
-    // getting font and setting its size to 3.5 the size of the marker size
+    // getting font and setting its size to 3 the size of the marker size
     CGFloat fontSize = ([self markerSize] / [UIScreen mainScreen].scale) / 3;
     UIFont *textFont =  [UIFont fontWithName:self.fontPath size:fontSize];
     CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
@@ -17,23 +17,35 @@ Object _offsetToJson(Offset offset) {
 enum MarkerType {
   /// A white circle with text in the middle. If chosen, an label must
   /// be passed in the label argument.
-  count,
+  cluster,
 
   /// A white text bubble with text in the middle. The bubble adjusts itself
   /// to the text. If chosen, an label must be passed in the label argument.
   price,
 
-  /// A white rounded square with text in the middle. The shape adjusts itself
+  /// A white pin with text in the middle. The shape adjusts itself
   /// to the text. If chosen, an label must be passed in the label argument.
-  rounded,
+  pin_cluster,
 
-  /// A grey rounded square with fading text in the middle. The shape adjusts itself
+  /// A grey pin with fading text in the middle. The shape adjusts itself
   /// to the text. If chosen, an label must be passed in the label argument.
-  rounded_visited,
+  pin_cluster_visited,
 
-  /// A blue rounded square with white text in the middle. The shape adjusts itself
+  /// A blue pin with white text in the middle. The shape adjusts itself
   /// to the text. If chosen, an label must be passed in the label argument.
-  rounded_selected,
+  pin_cluster_selected,
+
+  /// A white pin with text in the middle and a tail. The shape adjusts itself
+  /// to the text. If chosen, an label must be passed in the label argument.
+  pin_price,
+
+  /// A grey pin with fading text in the middle and a tail. The shape adjusts itself
+  /// to the text. If chosen, an label must be passed in the label argument.
+  pin_price_visited,
+
+  /// A blue pin with white text in the middle and a tail. The shape adjusts itself
+  /// to the text. If chosen, an label must be passed in the label argument.
+  pin_price_selected,
 
   /// A non-standard icon. If chosen, an icon must be passed in the icon
   /// argument.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork
+      ref: v2.2.3-fork.1
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.1-fork.6.1
+      ref: v2.2.3-fork
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0


### PR DESCRIPTION
This PR adds new price pins to markers options, and changes marker naming to avoid confusion.
Now the markers names are:
- **price**, with no changes in the name
- **cluster**, with the old name being "count"
- **pin_cluster**, with the old name being "rounded"
- **pin_cluster_visited**, with the old name being "rounded_visited"
- **pin_cluster_selected**, with the old name being "rounded_selected"

And the new pins are as followed:
- pin_price
<img width="377" alt="image" src="https://user-images.githubusercontent.com/109806620/225509258-9b8e7e57-5827-47cb-92b3-ccba20d8bc34.png">

- pin_price_visited:
<img width="376" alt="image" src="https://user-images.githubusercontent.com/109806620/225509500-ab68044d-49be-41a1-9ef3-21c128a28ea2.png">

- pin_price_selected:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/109806620/225509401-79b6b461-3fc5-44b5-a9be-069eb4d5722a.png">


