### PR TITLE
fix new markers layout

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -137,59 +137,60 @@ public class CozyMarkerBuilder {
     }
 
     private Bitmap getPinBitmap(String text, int markerColor, int textColor, boolean hasTail) {
-
         // gets the text size based on the font
         Rect rect = new Rect();
-        float textSize = size / 3.5f;
+        float textSize = getDpFromPx(12f);
         Paint priceMarkerTextStyle = getTextPaint(textSize, textColor);
         priceMarkerTextStyle.getTextBounds(text, 0, text.length(), rect);
 
-        // calculates if the minimum width will
-        // be a specific size or is adjusted to the width of the string
-        int smallestPinSize = size / 2;
-        int minWidth = Math.max(rect.width(), smallestPinSize);
+        // set the marker width
+        int paddingVertical = Math.round(getDpFromPx(12f));
+        int paddingHorizontal = Math.round(getDpFromPx(11f));
+        int minMarkerWidth = Math.round(getDpFromPx(40f));
+        int strokeSize = 2;
+        int markerWidth = rect.width() + (2 * paddingHorizontal) + strokeSize;
+        if (markerWidth < minMarkerWidth) {
+            markerWidth = minMarkerWidth;
+        }
 
-        // set the marker width as the minimum width with space for padding and shadow
-        int padding = size / 2;
-        int shadowSize = 6;
-        int markerWidth = minWidth + padding + shadowSize;
-
-        // set the marker height as the string height with space for padding and shadow
-        int markerHeight = rect.height() + padding + shadowSize;
+        // set the marker height as the string height with space for padding and stroke
+        int markerHeight = rect.height() + (2 * paddingVertical) + strokeSize;
 
         // creates a bitmap with the marker width and height
-        // if a tail will be used, gets an extra spacing in the marker height for the
-        // tail
+        // if a tail will be used, gets an extra spacing in the marker height for the tail
         int priceTailSize = (hasTail ? (int) (priceMarkerTailSize / 1.5f) : 0);
         Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight + priceTailSize, Bitmap.Config.ARGB_8888);
 
-        // gets a bubble path, centering in a space for shadow on the left and top side
-        int shapeWidth = markerWidth - shadowSize;
-        int shapeHeight = markerHeight - shadowSize;
-        RectF shape = new RectF(shadowSize, shadowSize, shapeWidth, shapeHeight);
+        // gets a bubble path, centering in a space for stroke on the left and top side
+        int shapeWidth = markerWidth - strokeSize;
+        int shapeHeight = markerHeight - strokeSize;
+        RectF shape = new RectF(strokeSize, strokeSize, shapeWidth, shapeHeight);
 
-        // add the path, and if a tail is used, add a tail path on the bottom center of
-        // the marker
+        // add the path, and if a tail is used, add a tail path on the bottom center of the marker
         int shapeBorderRadius = 50;
         Path bubblePath = new Path();
         bubblePath.addRoundRect(shape, shapeBorderRadius, shapeBorderRadius, Path.Direction.CW);
         if (hasTail) {
-            bubblePath.addPath(addTailOnMarkerCenter(marker, priceTailSize, shadowSize));
+            Path tailPath = addTailOnMarkerCenter(marker, priceTailSize, strokeSize);
+            bubblePath.op(bubblePath, tailPath, Path.Op.UNION);
         }
 
-        // sets the shadow and marker paint
-        Paint paint = new Paint();
-        paint.setAntiAlias(true);
-        paint.setStyle(Paint.Style.STROKE);
-        paint.setStrokeWidth(shadowSize);
-        int shadowColor = Color.argb(128, 0, 0, 0);
-        paint.setShadowLayer(shadowSize, 0, 0, shadowColor);
-        paint.setStyle(Paint.Style.FILL);
-        paint.setColor(markerColor);
+        Paint fillPaint = new Paint();
+        fillPaint.setAntiAlias(true);
+        fillPaint.setStyle(Paint.Style.FILL);
+        fillPaint.setColor(markerColor);
+
+        Paint strokePaint = new Paint();
+        strokePaint.setAntiAlias(true);
+        strokePaint.setStyle(Paint.Style.STROKE);
+        strokePaint.setColor(Color.parseColor("#D9DBD0"));
+        strokePaint.setStrokeWidth(2);
+        strokePaint.setStrokeCap(Paint.Cap.ROUND);
 
         // draws the path
         Canvas canvas = new Canvas(marker);
-        canvas.drawPath(bubblePath, paint);
+        canvas.drawPath(bubblePath, fillPaint);
+        canvas.drawPath(bubblePath, strokePaint);
 
         // gets the text offset from the marker and draws it
         float dx = getTextXOffset(markerWidth, rect);
@@ -220,6 +221,10 @@ public class CozyMarkerBuilder {
             default:
                 return null;
         }
+    }
+
+    private static float getDpFromPx(float px){
+        return px * Resources.getSystem().getDisplayMetrics().density;
     }
 
     private Bitmap copyOnlyBitmapProperties(Bitmap bitmap) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -167,7 +167,7 @@ public class CozyMarkerBuilder {
         RectF shape = new RectF(strokeSize, strokeSize, shapeWidth, shapeHeight);
 
         // add the path, and if a tail is used, add a tail path on the bottom center of the marker
-        int shapeBorderRadius = 50;
+        int shapeBorderRadius = Math.round(getDpFromPx(50));
         Path bubblePath = new Path();
         bubblePath.addRoundRect(shape, shapeBorderRadius, shapeBorderRadius, Path.Direction.CW);
         if (hasTail) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -165,23 +165,30 @@ void CFSafeRelease(CFTypeRef cf) {
 - (UIImage *)pinMarkerImageWithText:(NSString *)text withMarkerColor:(UIColor *)color withTextColor:(UIColor *)textColor withTail:(BOOL)withTail {
     
     // getting font and setting its size to 3 the size of the marker size
-    CGFloat fontSize = ([self markerSize] / [UIScreen mainScreen].scale) / 3;
+    CGFloat fontSize = 12;
     UIFont *textFont =  [UIFont fontWithName:self.fontPath size:fontSize];
     CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
     
-    // setting padding and shadow width
-    CGFloat padding = 20;
-    CGFloat shadowWidth = 2;
+    // setting padding and stroke size
+    CGFloat paddingHorizontal = 11;
+    CGFloat paddingVertical = 12;
+    CGFloat strokeSize = 1;
+
+    // setting stroke color
+    UIColor *strokeColor = [UIColor colorWithRed:212.0f/255.0f green:(214.0f/255.0f) blue:(202.0f/255.0f) alpha:1];
 
     // setting marker width with a minimum width in case the string size is below the minimum
-    CGFloat minMarkerWidth = ([self markerSize] / [UIScreen mainScreen].scale) / 2;
-    CGFloat markerWidth = ((stringSize.width > minMarkerWidth) ? stringSize.width : minMarkerWidth) + padding + shadowWidth;
-    
+    CGFloat minMarkerWidth = 40;
+    CGFloat markerWidth = stringSize.width + (2 * paddingVertical) + (2 * strokeSize);
+    if(markerWidth < minMarkerWidth) {
+        markerWidth = minMarkerWidth;
+    }
+     
     // in case a tail will be used, sets a tail size, else it becomes 0.
     CGFloat tailSize = withTail ? 6 : 0;
     
     // setting the marker height
-    CGFloat markerHeight = stringSize.height + padding + shadowWidth + tailSize;
+    CGFloat markerHeight = stringSize.height + (2 * paddingHorizontal) + (2 * strokeSize) + tailSize;
 
     
     // creating canvas
@@ -191,22 +198,21 @@ void CFSafeRelease(CFTypeRef cf) {
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
     UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         
-        // setting colors and shadows
-        CGContextSetShadowWithColor(rendererContext.CGContext, CGSizeMake(0, 0), 2.0, UIColor.grayColor.CGColor);
+        // setting colors and stroke
         CGContextSetAlpha(rendererContext.CGContext, 1.0);
         CGContextSetFillColorWithColor(rendererContext.CGContext, color.CGColor);
-        CGContextSetStrokeColorWithColor(rendererContext.CGContext, UIColor.clearColor.CGColor);
+        CGContextSetStrokeColorWithColor(rendererContext.CGContext, strokeColor.CGColor);
         CGContextSetLineWidth(rendererContext.CGContext, 5);
         CGContextSetLineJoin(rendererContext.CGContext, 0);
         
         // drawing bubble from point x/y, and with width and height
-        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(shadowWidth / 2, shadowWidth / 2, markerWidth - shadowWidth, markerHeight - shadowWidth - tailSize) cornerRadius:20];
+        UIBezierPath *bezier = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(1, 1, markerWidth - (2 * strokeSize), markerHeight - (2 * strokeSize) - tailSize) cornerRadius:20];
         
         // if a tail will be used, sets a point in the bottom center of the bubble,
         // draws a triangle from this point and adds to the bubble path above
         if(withTail) {
             CGFloat x = canvas.width / 2;
-            CGFloat y = markerHeight - tailSize - shadowWidth / 2;
+            CGFloat y = markerHeight - tailSize - strokeSize;
             
             UIBezierPath *tailPath = [UIBezierPath bezierPath];
             [tailPath moveToPoint:CGPointMake(x - tailSize, y)];
@@ -220,8 +226,7 @@ void CFSafeRelease(CFTypeRef cf) {
         [bezier stroke];
         [bezier fill];
      
-        // removes the shadow and draws the text
-        CGContextSetShadowWithColor(rendererContext.CGContext, CGSizeMake(0, 0), 0.0, NULL);
+        // draws the text
         CGFloat textY = ((canvas.height - tailSize) / 2) - (stringSize.height / 2);
         CGFloat textX = (canvas.width / 2) - (stringSize.width / 2);
         CGRect textRect = CGRectMake(textX, textY, stringSize.width, stringSize.height);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: 'fix_pin_layout'
+      ref: v2.2.3-fork.3
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.2
+      ref: 'fix_pin_layout'
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0


### PR DESCRIPTION
This PR fixes the layout of the new markers by applying the following changes:
- Font size adjustment
- Adjustment of the paddings
- Shadow removal
- Apply stroke

<table>
<tr>
<th>iOS - Before</th>
<th>iOS - After</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/97969630/227725034-356fe229-8aa1-4e39-b173-64c32f99b540.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/97969630/227725054-cd7dc53e-3a89-46a1-b007-37a945eff2a7.png">
</td>
</tr>
</table>

<table>
<tr>
<th>Android - Before</th>
<th>Android - After</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/97969630/227725071-7eff0ee2-2e20-40f3-91fd-bd4afc9e16a5.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/97969630/227725080-00867003-a9ee-4627-9820-658e800bf818.png">
</td>
</tr>
</table>