### PR TITLE
feat(NXP-91): Adding icons to markers

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/build.gradle
@@ -35,6 +35,7 @@ android {
     dependencies {
         implementation "androidx.annotation:annotation:1.1.0"
         implementation 'com.google.android.gms:play-services-maps:18.1.0'
+        implementation 'com.caverock:androidsvg-aar:1.4'
         androidTestImplementation 'androidx.test:runner:1.2.0'
         androidTestImplementation 'androidx.test:rules:1.4.0'
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -457,7 +457,7 @@ class Convert {
     final Bitmap bitmap = cozyMarkerBuilder.buildMarker(new CozyMarkerData(
       (String) cozyMarkerData.get("label"),
       (String) cozyMarkerData.get("icon"),
-      (boolean) cozyMarkerData.get("hasTail"),
+      (boolean) cozyMarkerData.get("hasPointer"),
       (boolean) cozyMarkerData.get("isSelected"),
       (boolean) cozyMarkerData.get("isVisualized"),
       (String) cozyMarkerData.get("state"),

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -414,14 +414,15 @@ class Convert {
     if (flat != null) {
       sink.setFlat(toBoolean(flat));
     }
-    final Object icon = data.get("icon");
-    if (icon != null) {
-      sink.setIcon(toBitmapDescriptor(icon));
-    }
     
     final Object cozyMarkerData = data.get("cozyMarkerData");
     if(cozyMarkerData != null){
       interpretCozyMarkerData(sink, toObjectMap(cozyMarkerData), cozyMarkerBuilder);
+    }else{
+      final Object icon = data.get("icon");
+      if (icon != null) {
+        sink.setIcon(toBitmapDescriptor(icon));
+      }
     }
 
     final Object infoWindow = data.get("infoWindow");
@@ -455,6 +456,7 @@ class Convert {
   private static void interpretCozyMarkerData(MarkerOptionsSink sink, Map<String, Object> cozyMarkerData, CozyMarkerBuilder cozyMarkerBuilder) {
     final Bitmap bitmap = cozyMarkerBuilder.buildMarker(new CozyMarkerData(
       (String) cozyMarkerData.get("label"),
+      (String) cozyMarkerData.get("icon"),
       (boolean) cozyMarkerData.get("hasPointer"),
       (boolean) cozyMarkerData.get("isSelected"),
       (boolean) cozyMarkerData.get("isVisualized"),

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -457,7 +457,7 @@ class Convert {
     final Bitmap bitmap = cozyMarkerBuilder.buildMarker(new CozyMarkerData(
       (String) cozyMarkerData.get("label"),
       (String) cozyMarkerData.get("icon"),
-      (boolean) cozyMarkerData.get("hasPointer"),
+      (boolean) cozyMarkerData.get("hasTail"),
       (boolean) cozyMarkerData.get("isSelected"),
       (boolean) cozyMarkerData.get("isVisualized"),
       (String) cozyMarkerData.get("state"),

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -42,7 +42,7 @@ public class CozyMarkerBuilder {
         return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
     }
 
-    private Path addTailOnMarkerCenter(Bitmap marker, int pointerWidth, int pointerHeight, int shadowSize) {
+    private Path addPointerOnMarkerCenter(Bitmap marker, int pointerWidth, int pointerHeight, int shadowSize) {
         Path pointer = new Path();
         pointer.setFillType(Path.FillType.EVEN_ODD);
         float width = marker.getWidth();
@@ -175,8 +175,8 @@ public class CozyMarkerBuilder {
 
         // add pointer to shape if needed
         if (hasPointer) {
-            Path tailPath = addTailOnMarkerCenter(marker, pointerWidth, pointerHeight, strokeSize);
-            bubblePath.op(bubblePath, tailPath, Path.Op.UNION);
+            Path pointerPath = addPointerOnMarkerCenter(marker, pointerWidth, pointerHeight, strokeSize);
+            bubblePath.op(bubblePath, pointerPath, Path.Op.UNION);
         }
 
         Paint fillPaint = new Paint();
@@ -195,11 +195,6 @@ public class CozyMarkerBuilder {
         Canvas canvas = new Canvas(marker);
         canvas.drawPath(bubblePath, fillPaint);
         canvas.drawPath(bubblePath, strokePaint);
-
-        Paint fillPaint2 = new Paint();
-        fillPaint2.setAntiAlias(true);
-        fillPaint2.setStyle(Paint.Style.FILL);
-        fillPaint2.setColor(Color.RED);
        
         // draws the text
         float dx = getTextXOffset(markerWidth, textBounds) + iconAdditionalWidth/2;

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -203,14 +203,8 @@ public class CozyMarkerBuilder {
         strokePaint.setStrokeWidth(strokeSize);
         strokePaint.setStrokeCap(Paint.Cap.ROUND);
 
-        Paint fillPaint2 = new Paint();
-        fillPaint2.setAntiAlias(true);
-        fillPaint2.setStyle(Paint.Style.FILL);
-        fillPaint2.setColor(Color.RED);
-
         // draws the bubble
         Canvas canvas = new Canvas(marker);
-        canvas.drawRect(0, 0, markerWidth, markerHeight + pointerSize, fillPaint2);
         canvas.drawPath(bubblePath, fillPaint);
         canvas.drawPath(bubblePath, strokePaint);
        

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -13,6 +13,8 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Typeface;
 import com.caverock.androidsvg.SVG;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import androidx.core.content.res.ResourcesCompat;
 
@@ -42,17 +44,17 @@ public class CozyMarkerBuilder {
         return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
     }
 
-    private Path addPointerOnMarkerCenter(Bitmap marker, int pointerWidth, int pointerHeight, int shadowSize) {
-        Path pointer = new Path();
-        pointer.setFillType(Path.FillType.EVEN_ODD);
+    private Path addTailOnMarkerCenter(Bitmap marker, int tailWidth, int tailHeight, int shadowSize) {
+        Path tail = new Path();
+        tail.setFillType(Path.FillType.EVEN_ODD);
         float width = marker.getWidth();
-        float height = marker.getHeight() - pointerHeight - shadowSize;
-        pointer.moveTo(width / 2f - pointerWidth, height);
-        pointer.lineTo(width / 2f + pointerWidth, height);
-        pointer.lineTo(width / 2f, height + pointerHeight);
-        pointer.lineTo(width / 2f - pointerWidth, height);
-        pointer.close();
-        return pointer;
+        float height = marker.getHeight() - tailHeight - shadowSize;
+        tail.moveTo(width / 2f - tailWidth, height);
+        tail.lineTo(width / 2f + tailWidth, height);
+        tail.lineTo(width / 2f, height + tailHeight);
+        tail.lineTo(width / 2f - tailWidth, height);
+        tail.close();
+        return tail;
     }
 
     private Bitmap getIconBitmap(String svgIcon, int width, int height) {
@@ -66,10 +68,20 @@ public class CozyMarkerBuilder {
 
         try{
             //Needed this because svg doesn't scale if there is fixed width and height
-            String finalSvgIcon = svgIcon.replaceAll("width=\"24\" height=\"24\" ", "");
-            SVG  svg = SVG.getFromString(finalSvgIcon);
-            svg.setDocumentViewBox(0,0,24,24);
+            String widthPattern = "(width=\")(.+?)(\")";
+            String heightPattern = "(height=\")(.+?)(\")";
 
+            Matcher widthMatcher = Pattern.compile(widthPattern).matcher(svgIcon);
+            Matcher heightMatcher = Pattern.compile(heightPattern).matcher(svgIcon);
+
+            String finalSvgIcon = svgIcon.replaceAll(widthPattern, "");
+            finalSvgIcon = finalSvgIcon.replaceAll(heightPattern, "");
+
+            SVG  svg = SVG.getFromString(finalSvgIcon);
+            if(widthMatcher.find() && heightMatcher.find()){
+                svg.setDocumentViewBox(0,0,Integer.parseInt(widthMatcher.group(2)),Integer.parseInt(heightMatcher.group(2)));
+            }
+            
             Bitmap iconBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(iconBitmap);
             svg.renderToCanvas(canvas, new RectF(0, 0, width, height));
@@ -83,20 +95,20 @@ public class CozyMarkerBuilder {
 
     private Bitmap getMarkerBitmap(CozyMarkerData markerData) {
         String text = markerData.label;
-        boolean hasPointer = markerData.hasPointer;
+        boolean hasTail = markerData.hasTail;
 
         /* setting colors */
-        int defaultMarkerColor = Color.WHITE;
-        int defaultTextColor = Color.BLACK;
-        int defaultIconCircleColor = Color.rgb(248, 249, 245);
+        final int defaultMarkerColor = Color.WHITE;
+        final int defaultTextColor = Color.BLACK;
+        final int defaultIconCircleColor = Color.rgb(248, 249, 245);
 
-        int selectedMarkerColor = Color.rgb(57, 87, 189);
-        int selectedTextColor = Color.WHITE;
-        int selectedIconCircleColor = Color.WHITE;
+        final int selectedMarkerColor = Color.rgb(57, 87, 189);
+        final int selectedTextColor = Color.WHITE;
+        final int selectedIconCircleColor = Color.WHITE;
 
-        int visualizedMarkerColor = Color.rgb(248, 249, 245);
-        int visualizedTextColor = Color.rgb(110, 110, 100);
-        int visualizedIconCircleColor = Color.WHITE;
+        final int visualizedMarkerColor = Color.rgb(248, 249, 245);
+        final int visualizedTextColor = Color.rgb(110, 110, 100);
+        final int visualizedIconCircleColor = Color.WHITE;
 
         int markerColor = defaultMarkerColor;
         int textColor = defaultTextColor;
@@ -115,20 +127,20 @@ public class CozyMarkerBuilder {
 
         /* setting constants */
         // setting global constants
-        int paddingVertical = Math.round(getDpFromPx(12));
-        int paddingHorizontal = Math.round(getDpFromPx(11.5f));
-        int minMarkerWidth = Math.round(getDpFromPx(40));
-        int strokeSize = Math.round(getDpFromPx(1.5f));
+        final int paddingVertical = Math.round(getDpFromPx(12));
+        final int paddingHorizontal = Math.round(getDpFromPx(11.5f));
+        final int minMarkerWidth = Math.round(getDpFromPx(40));
+        final int strokeSize = Math.round(getDpFromPx(1.5f));
 
-        // setting constants for pointer
-        int pointerWidth = Math.round(getDpFromPx(7));
-        int pointerHeight = Math.round(getDpFromPx(6));
+        // setting constants for tail
+        final int tailWidth = Math.round(getDpFromPx(7));
+        final int tailHeight = Math.round(getDpFromPx(6));
         
         // setting constants for icon
-        int iconSize =  Math.round(getDpFromPx(16));
-        int iconCircleSize =  Math.round(getDpFromPx(24));
-        int iconLeftPadding =  Math.round(getDpFromPx(5));
-        int iconRightPadding =  Math.round(getDpFromPx(3));
+        final int iconSize =  Math.round(getDpFromPx(16));
+        final int iconCircleSize =  Math.round(getDpFromPx(24));
+        final int iconLeftPadding =  Math.round(getDpFromPx(5));
+        final int iconRightPadding =  Math.round(getDpFromPx(3));
 
         /* setting variables */
         // gets the text size based on the font
@@ -141,10 +153,10 @@ public class CozyMarkerBuilder {
         Bitmap iconBitmap = getIconBitmap(markerData.icon,iconSize,iconSize);
 
         // additionalIconWidth to be used on markerWidth
-        int iconAdditionalWidth = iconBitmap != null ? iconCircleSize + iconRightPadding : 0;
+        final int iconAdditionalWidth = iconBitmap != null ? iconCircleSize + iconRightPadding : 0;
 
-        // pointerSize to be used on bitmap creation
-        int pointerSize = (hasPointer ? pointerHeight : 0);
+        // tailSize to be used on bitmap creation
+        final int tailSize = (hasTail ? tailHeight : 0);
         
         // setting marker width with a minimum width in case the string size is below the minimum
         int markerWidth = textBounds.width() + (2 * paddingHorizontal) + (2 * strokeSize) + iconAdditionalWidth;
@@ -153,11 +165,11 @@ public class CozyMarkerBuilder {
         }
 
         // set the marker height as the string height with space for padding and stroke
-        int markerHeight = textBounds.height() + (2 * paddingVertical) + 2 * strokeSize;
+        final int markerHeight = textBounds.height() + (2 * paddingVertical) + 2 * strokeSize;
 
         // gets a bubble path, centering in a space for stroke on the left and top side
-        int bubbleShapeWidth = markerWidth - strokeSize/2;
-        int bubbleShapeHeight = markerHeight - strokeSize/2;
+        final int bubbleShapeWidth = markerWidth - strokeSize/2;
+        final int bubbleShapeHeight = markerHeight - strokeSize/2;
 
         // other important variables
         float middleOfMarkerY = (bubbleShapeHeight / 2) + strokeSize/2;
@@ -165,18 +177,18 @@ public class CozyMarkerBuilder {
 
         /* start of drawing */
         // creates the marker bitmap
-        Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight + pointerSize, Bitmap.Config.ARGB_8888);
+        Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight + tailSize, Bitmap.Config.ARGB_8888);
         
         // create the bubble shape
         RectF bubbleShape = new RectF(strokeSize/2, strokeSize/2, bubbleShapeWidth, bubbleShapeHeight);
-        int shapeBorderRadius = Math.round(getDpFromPx(50));
+        final int shapeBorderRadius = Math.round(getDpFromPx(50));
         Path bubblePath = new Path();
         bubblePath.addRoundRect(bubbleShape, shapeBorderRadius, shapeBorderRadius, Path.Direction.CW);
 
-        // add pointer to shape if needed
-        if (hasPointer) {
-            Path pointerPath = addPointerOnMarkerCenter(marker, pointerWidth, pointerHeight, strokeSize);
-            bubblePath.op(bubblePath, pointerPath, Path.Op.UNION);
+        // add tail to shape if needed
+        if (hasTail) {
+            Path tailPath = addTailOnMarkerCenter(marker, tailWidth, tailHeight, strokeSize);
+            bubblePath.op(bubblePath, tailPath, Path.Op.UNION);
         }
 
         Paint fillPaint = new Paint();

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerBuilder.java
@@ -44,17 +44,17 @@ public class CozyMarkerBuilder {
         return (markerWidth / 2f) - (rect.width() / 2f) - rect.left;
     }
 
-    private Path addTailOnMarkerCenter(Bitmap marker, int tailWidth, int tailHeight, int shadowSize) {
-        Path tail = new Path();
-        tail.setFillType(Path.FillType.EVEN_ODD);
+    private Path addPointerOnMarkerCenter(Bitmap marker, int pointerWidth, int pointerHeight, int shadowSize) {
+        Path pointer = new Path();
+        pointer.setFillType(Path.FillType.EVEN_ODD);
         float width = marker.getWidth();
-        float height = marker.getHeight() - tailHeight - shadowSize;
-        tail.moveTo(width / 2f - tailWidth, height);
-        tail.lineTo(width / 2f + tailWidth, height);
-        tail.lineTo(width / 2f, height + tailHeight);
-        tail.lineTo(width / 2f - tailWidth, height);
-        tail.close();
-        return tail;
+        float height = marker.getHeight() - pointerHeight - shadowSize;
+        pointer.moveTo(width / 2f - pointerWidth, height);
+        pointer.lineTo(width / 2f + pointerWidth, height);
+        pointer.lineTo(width / 2f, height + pointerHeight);
+        pointer.lineTo(width / 2f - pointerWidth, height);
+        pointer.close();
+        return pointer;
     }
 
     private Bitmap getIconBitmap(String svgIcon, int width, int height) {
@@ -95,7 +95,7 @@ public class CozyMarkerBuilder {
 
     private Bitmap getMarkerBitmap(CozyMarkerData markerData) {
         String text = markerData.label;
-        boolean hasTail = markerData.hasTail;
+        boolean hasPointer = markerData.hasPointer;
 
         /* setting colors */
         final int defaultMarkerColor = Color.WHITE;
@@ -132,9 +132,9 @@ public class CozyMarkerBuilder {
         final int minMarkerWidth = Math.round(getDpFromPx(40));
         final int strokeSize = Math.round(getDpFromPx(1.5f));
 
-        // setting constants for tail
-        final int tailWidth = Math.round(getDpFromPx(7));
-        final int tailHeight = Math.round(getDpFromPx(6));
+        // setting constants for pointer
+        final int pointerWidth = Math.round(getDpFromPx(7));
+        final int pointerHeight = Math.round(getDpFromPx(6));
         
         // setting constants for icon
         final int iconSize =  Math.round(getDpFromPx(16));
@@ -155,8 +155,8 @@ public class CozyMarkerBuilder {
         // additionalIconWidth to be used on markerWidth
         final int iconAdditionalWidth = iconBitmap != null ? iconCircleSize + iconRightPadding : 0;
 
-        // tailSize to be used on bitmap creation
-        final int tailSize = (hasTail ? tailHeight : 0);
+        // pointerSize to be used on bitmap creation
+        final int pointerSize = (hasPointer ? pointerHeight : 0);
         
         // setting marker width with a minimum width in case the string size is below the minimum
         int markerWidth = textBounds.width() + (2 * paddingHorizontal) + (2 * strokeSize) + iconAdditionalWidth;
@@ -177,7 +177,7 @@ public class CozyMarkerBuilder {
 
         /* start of drawing */
         // creates the marker bitmap
-        Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight + tailSize, Bitmap.Config.ARGB_8888);
+        Bitmap marker = Bitmap.createBitmap(markerWidth, markerHeight + pointerSize, Bitmap.Config.ARGB_8888);
         
         // create the bubble shape
         RectF bubbleShape = new RectF(strokeSize/2, strokeSize/2, bubbleShapeWidth, bubbleShapeHeight);
@@ -185,10 +185,10 @@ public class CozyMarkerBuilder {
         Path bubblePath = new Path();
         bubblePath.addRoundRect(bubbleShape, shapeBorderRadius, shapeBorderRadius, Path.Direction.CW);
 
-        // add tail to shape if needed
-        if (hasTail) {
-            Path tailPath = addTailOnMarkerCenter(marker, tailWidth, tailHeight, strokeSize);
-            bubblePath.op(bubblePath, tailPath, Path.Op.UNION);
+        // add pointer to shape if needed
+        if (hasPointer) {
+            Path pointerPath = addPointerOnMarkerCenter(marker, pointerWidth, pointerHeight, strokeSize);
+            bubblePath.op(bubblePath, pointerPath, Path.Op.UNION);
         }
 
         Paint fillPaint = new Paint();
@@ -203,8 +203,14 @@ public class CozyMarkerBuilder {
         strokePaint.setStrokeWidth(strokeSize);
         strokePaint.setStrokeCap(Paint.Cap.ROUND);
 
+        Paint fillPaint2 = new Paint();
+        fillPaint2.setAntiAlias(true);
+        fillPaint2.setStyle(Paint.Style.FILL);
+        fillPaint2.setColor(Color.RED);
+
         // draws the bubble
         Canvas canvas = new Canvas(marker);
+        canvas.drawRect(0, 0, markerWidth, markerHeight + pointerSize, fillPaint2);
         canvas.drawPath(bubblePath, fillPaint);
         canvas.drawPath(bubblePath, strokePaint);
        

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
@@ -3,17 +3,17 @@ package io.flutter.plugins.googlemaps;
 public class CozyMarkerData {
     public final String label;
     public final String icon;
-    public final boolean hasPointer;
+    public final boolean hasTail;
     public final boolean isSelected;
     public final boolean isVisualized;
     public final String state;
     public final String variant;
     public final String size;
 
-    public CozyMarkerData(String label, String icon, boolean hasPointer, boolean isSelected, boolean isVisualized, String state, String variant, String size) {
+    public CozyMarkerData(String label, String icon, boolean hasTail, boolean isSelected, boolean isVisualized, String state, String variant, String size) {
         this.label = label;
         this.icon = icon;
-        this.hasPointer = hasPointer;
+        this.hasTail = hasTail;
         this.isSelected = isSelected;
         this.isVisualized = isVisualized;
         this.state = state;
@@ -23,6 +23,6 @@ public class CozyMarkerData {
     
     @Override
     public String toString() {
-        return label + icon + hasPointer + isSelected + isVisualized + state + variant + size;
+        return label + icon + hasTail + isSelected + isVisualized + state + variant + size;
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
@@ -3,17 +3,17 @@ package io.flutter.plugins.googlemaps;
 public class CozyMarkerData {
     public final String label;
     public final String icon;
-    public final boolean hasTail;
+    public final boolean hasPointer;
     public final boolean isSelected;
     public final boolean isVisualized;
     public final String state;
     public final String variant;
     public final String size;
 
-    public CozyMarkerData(String label, String icon, boolean hasTail, boolean isSelected, boolean isVisualized, String state, String variant, String size) {
+    public CozyMarkerData(String label, String icon, boolean hasPointer, boolean isSelected, boolean isVisualized, String state, String variant, String size) {
         this.label = label;
         this.icon = icon;
-        this.hasTail = hasTail;
+        this.hasPointer = hasPointer;
         this.isSelected = isSelected;
         this.isVisualized = isVisualized;
         this.state = state;
@@ -23,6 +23,6 @@ public class CozyMarkerData {
     
     @Override
     public String toString() {
-        return label + icon + hasTail + isSelected + isVisualized + state + variant + size;
+        return label + icon + hasPointer + isSelected + isVisualized + state + variant + size;
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
@@ -21,7 +21,6 @@ public class CozyMarkerData {
         this.size = size;
     }
     
-    //TODO: add hashCode for bitmap
     @Override
     public String toString() {
         return label + icon + hasPointer + isSelected + isVisualized + state + variant + size;

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/CozyMarkerData.java
@@ -2,6 +2,7 @@ package io.flutter.plugins.googlemaps;
 
 public class CozyMarkerData {
     public final String label;
+    public final String icon;
     public final boolean hasPointer;
     public final boolean isSelected;
     public final boolean isVisualized;
@@ -9,8 +10,9 @@ public class CozyMarkerData {
     public final String variant;
     public final String size;
 
-    public CozyMarkerData(String label, boolean hasPointer, boolean isSelected, boolean isVisualized, String state, String variant, String size) {
+    public CozyMarkerData(String label, String icon, boolean hasPointer, boolean isSelected, boolean isVisualized, String state, String variant, String size) {
         this.label = label;
+        this.icon = icon;
         this.hasPointer = hasPointer;
         this.isSelected = isSelected;
         this.isVisualized = isVisualized;
@@ -18,9 +20,10 @@ public class CozyMarkerData {
         this.variant = variant;
         this.size = size;
     }
-
+    
+    //TODO: add hashCode for bitmap
     @Override
     public String toString() {
-        return label + hasPointer + isSelected + isVisualized + state + variant + size;
+        return label + icon + hasPointer + isSelected + isVisualized + state + variant + size;
     }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -161,10 +161,6 @@ void CFSafeRelease(CFTypeRef cf) {
     
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
     UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
-        
-        CGContextSetAlpha(rendererContext.CGContext, 1.0);
-        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.redColor.CGColor);
-        CGContextFillRect(rendererContext.CGContext, CGRectMake(0, 0, canvas.width, canvas.height));
 
         // setting colors and stroke
         CGContextSetAlpha(rendererContext.CGContext, 1.0);

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -78,20 +78,20 @@ void CFSafeRelease(CFTypeRef cf) {
 - (UIImage *)getMarkerWithData:(CozyMarkerData *)cozyMarkerData {
     NSString *text = cozyMarkerData.label;
     NSString *icon = cozyMarkerData.icon;
-    BOOL hasPointer = cozyMarkerData.hasPointer;
+    BOOL hasTail = cozyMarkerData.hasTail;
 
     /* setting colors */
-    UIColor *defaultMarkerColor = UIColor.whiteColor;
-    UIColor *defaultTextColor = UIColor.blackColor;
-    UIColor *defaultIconCircleColor = [UIColor colorWithRed:(248.0f/255.0f) green:(249.f/255.0f) blue:(245.0f/255.0f) alpha:1];
+    UIColor * const defaultMarkerColor = UIColor.whiteColor;
+    UIColor * const defaultTextColor = UIColor.blackColor;
+    UIColor * const defaultIconCircleColor = [UIColor colorWithRed:(248.0f/255.0f) green:(249.f/255.0f) blue:(245.0f/255.0f) alpha:1];
     
-    UIColor *selectedMarkerColor = [UIColor colorWithRed:(57.0f/255.0f) green:(87.0f/255.0f) blue:(189.0f/255.0f) alpha:1];
-    UIColor *selectedTextColor = UIColor.whiteColor;
-    UIColor *selectedIconCircleColor = UIColor.whiteColor;
+    UIColor * const selectedMarkerColor = [UIColor colorWithRed:(57.0f/255.0f) green:(87.0f/255.0f) blue:(189.0f/255.0f) alpha:1];
+    UIColor * const selectedTextColor = UIColor.whiteColor;
+    UIColor * const selectedIconCircleColor = UIColor.whiteColor;
     
-    UIColor *visualizedMarkerColor = [UIColor colorWithRed:(248.0f/255.0f) green:(249.0f/255.0f) blue:(245.0f/255.0f) alpha:1];
-    UIColor *visualizedTextColor = [UIColor colorWithRed:(110.0f/255.0f) green:(110.0f/255.0f) blue:(100.0f/255.0f) alpha:1];
-    UIColor *visualizedIconCircleColor = UIColor.whiteColor;
+    UIColor * const visualizedMarkerColor = [UIColor colorWithRed:(248.0f/255.0f) green:(249.0f/255.0f) blue:(245.0f/255.0f) alpha:1];
+    UIColor * const visualizedTextColor = [UIColor colorWithRed:(110.0f/255.0f) green:(110.0f/255.0f) blue:(100.0f/255.0f) alpha:1];
+    UIColor * const visualizedIconCircleColor = UIColor.whiteColor;
 
     UIColor *markerColor = defaultMarkerColor;
     UIColor *textColor = defaultTextColor;
@@ -111,32 +111,32 @@ void CFSafeRelease(CFTypeRef cf) {
 
     /* setting constants */
     // setting padding and stroke size
-    CGFloat paddingVertical = 10.5f;
-    CGFloat paddingHorizontal = 11;
-    CGFloat minMarkerWidth = 40;
-    CGFloat strokeSize = 3;
+    const CGFloat paddingVertical = 10.5f;
+    const CGFloat paddingHorizontal = 11;
+    const CGFloat minMarkerWidth = 40;
+    const CGFloat strokeSize = 3;
 
-    // setting constants for pointer
-    CGFloat pointerWidth = 6;
-    CGFloat pointerHeight = 5;
+    // setting constants for tail
+    const CGFloat tailWidth = 6;
+    const CGFloat tailHeight = 5;
 
     // setting constants for icon
-    CGFloat iconSize = 16;
-    CGFloat iconCircleSize = 24;
-    CGFloat iconLeftPadding = 5;
-    CGFloat iconRightPadding = 3;
+    const CGFloat iconSize = 16;
+    const CGFloat iconCircleSize = 24;
+    const CGFloat iconLeftPadding = 5;
+    const CGFloat iconRightPadding = 3;
 
     /* setting variables */
     // getting font and setting its size to 3 the size of the marker size
-    CGFloat fontSize = 12;
+    const CGFloat fontSize = 12;
     UIFont *textFont =  [UIFont fontWithName:self.fontPath size:fontSize];
     CGSize stringSize = [text sizeWithAttributes:@{NSFontAttributeName:textFont}];
 
     // additionalIconWidth to be used on markerWidth
     CGFloat iconAdditionalWidth = icon != NULL ? iconCircleSize + iconRightPadding : 0;
     
-    // pointerSize to be used on bitmap creation
-    CGFloat pointerSize = hasPointer ? pointerHeight : 0;
+    // tailSize to be used on bitmap creation
+    CGFloat tailSize = hasTail ? tailHeight : 0;
     
     // setting marker width with a minimum width in case the string size is below the minimum
     CGFloat markerWidth = stringSize.width + (2 * paddingHorizontal) + (2 * strokeSize) + iconAdditionalWidth;
@@ -156,7 +156,7 @@ void CFSafeRelease(CFTypeRef cf) {
 
     /* start of drawing */
     // creating canvas
-    CGSize canvas = CGSizeMake(markerWidth, markerHeight + pointerSize);
+    CGSize canvas = CGSizeMake(markerWidth, markerHeight + tailSize);
     UIGraphicsBeginImageContext(canvas);
     
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
@@ -171,20 +171,20 @@ void CFSafeRelease(CFTypeRef cf) {
         // drawing bubble from point x/y, and with width and height
         UIBezierPath *bubblePath = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(strokeSize, strokeSize, bubbleShapeWidth, bubbleShapeHeight) cornerRadius:100];
         
-        // add pointer to shape if needed
-        if(hasPointer) {
+        // add tail to shape if needed
+        if(hasTail) {
             CGFloat x = canvas.width / 2;
             CGFloat y = markerHeight - strokeSize;
             
-            UIBezierPath *pointerPath = [UIBezierPath bezierPath];
-            [pointerPath moveToPoint:CGPointMake(x - pointerWidth, y)];
-            [pointerPath addLineToPoint:CGPointMake(x, y + pointerHeight)];
-            [pointerPath addLineToPoint:CGPointMake(x + pointerWidth, y)];
-            [pointerPath closePath];
-            [bubblePath appendPath:pointerPath];
+            UIBezierPath *tailPath = [UIBezierPath bezierPath];
+            [tailPath moveToPoint:CGPointMake(x - tailWidth, y)];
+            [tailPath addLineToPoint:CGPointMake(x, y + tailHeight)];
+            [tailPath addLineToPoint:CGPointMake(x + tailWidth, y)];
+            [tailPath closePath];
+            [bubblePath appendPath:tailPath];
         }
         
-        // draws the bubble with the pointer, if used
+        // draws the bubble with the tail, if used
         [bubblePath setLineWidth: strokeSize];
         [bubblePath stroke];
         [bubblePath fill];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerBuilder.m
@@ -78,7 +78,7 @@ void CFSafeRelease(CFTypeRef cf) {
 - (UIImage *)getMarkerWithData:(CozyMarkerData *)cozyMarkerData {
     NSString *text = cozyMarkerData.label;
     NSString *icon = cozyMarkerData.icon;
-    BOOL hasTail = cozyMarkerData.hasTail;
+    BOOL hasPointer = cozyMarkerData.hasPointer;
 
     /* setting colors */
     UIColor * const defaultMarkerColor = UIColor.whiteColor;
@@ -116,9 +116,9 @@ void CFSafeRelease(CFTypeRef cf) {
     const CGFloat minMarkerWidth = 40;
     const CGFloat strokeSize = 3;
 
-    // setting constants for tail
-    const CGFloat tailWidth = 6;
-    const CGFloat tailHeight = 5;
+    // setting constants for pointer
+    const CGFloat pointerWidth = 6;
+    const CGFloat pointerHeight = 5;
 
     // setting constants for icon
     const CGFloat iconSize = 16;
@@ -135,8 +135,8 @@ void CFSafeRelease(CFTypeRef cf) {
     // additionalIconWidth to be used on markerWidth
     CGFloat iconAdditionalWidth = icon != NULL ? iconCircleSize + iconRightPadding : 0;
     
-    // tailSize to be used on bitmap creation
-    CGFloat tailSize = hasTail ? tailHeight : 0;
+    // pointerSize to be used on bitmap creation
+    CGFloat pointerSize = hasPointer ? pointerHeight : 0;
     
     // setting marker width with a minimum width in case the string size is below the minimum
     CGFloat markerWidth = stringSize.width + (2 * paddingHorizontal) + (2 * strokeSize) + iconAdditionalWidth;
@@ -156,12 +156,16 @@ void CFSafeRelease(CFTypeRef cf) {
 
     /* start of drawing */
     // creating canvas
-    CGSize canvas = CGSizeMake(markerWidth, markerHeight + tailSize);
+    CGSize canvas = CGSizeMake(markerWidth, markerHeight + pointerSize);
     UIGraphicsBeginImageContext(canvas);
     
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize: canvas];
     UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         
+        CGContextSetAlpha(rendererContext.CGContext, 1.0);
+        CGContextSetFillColorWithColor(rendererContext.CGContext, UIColor.redColor.CGColor);
+        CGContextFillRect(rendererContext.CGContext, CGRectMake(0, 0, canvas.width, canvas.height));
+
         // setting colors and stroke
         CGContextSetAlpha(rendererContext.CGContext, 1.0);
         CGContextSetFillColorWithColor(rendererContext.CGContext, markerColor.CGColor);
@@ -171,20 +175,20 @@ void CFSafeRelease(CFTypeRef cf) {
         // drawing bubble from point x/y, and with width and height
         UIBezierPath *bubblePath = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(strokeSize, strokeSize, bubbleShapeWidth, bubbleShapeHeight) cornerRadius:100];
         
-        // add tail to shape if needed
-        if(hasTail) {
+        // add pointer to shape if needed
+        if(hasPointer) {
             CGFloat x = canvas.width / 2;
             CGFloat y = markerHeight - strokeSize;
             
-            UIBezierPath *tailPath = [UIBezierPath bezierPath];
-            [tailPath moveToPoint:CGPointMake(x - tailWidth, y)];
-            [tailPath addLineToPoint:CGPointMake(x, y + tailHeight)];
-            [tailPath addLineToPoint:CGPointMake(x + tailWidth, y)];
-            [tailPath closePath];
-            [bubblePath appendPath:tailPath];
+            UIBezierPath *pointerPath = [UIBezierPath bezierPath];
+            [pointerPath moveToPoint:CGPointMake(x - pointerWidth, y)];
+            [pointerPath addLineToPoint:CGPointMake(x, y + pointerHeight)];
+            [pointerPath addLineToPoint:CGPointMake(x + pointerWidth, y)];
+            [pointerPath closePath];
+            [bubblePath appendPath:pointerPath];
         }
         
-        // draws the bubble with the tail, if used
+        // draws the bubble with the pointer, if used
         [bubblePath setLineWidth: strokeSize];
         [bubblePath stroke];
         [bubblePath fill];

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.h
@@ -7,6 +7,7 @@
 
 @interface CozyMarkerData : NSObject
 - (instancetype)initWithLabel:(NSString *)label
+                         icon:(NSString *)icon
                   hasPointer:(BOOL)hasPointer
                    isSelected:(BOOL)isSelected
                    isVisualized:(BOOL)isVisualized
@@ -15,6 +16,7 @@
                          size:(NSString *)size;
 
 @property (nonatomic, strong) NSString *label;
+@property (nonatomic, strong) NSString *icon;
 @property (nonatomic, strong) NSString *state;
 @property (nonatomic, strong) NSString *variant;
 @property (nonatomic, strong) NSString *size;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.h
@@ -8,7 +8,7 @@
 @interface CozyMarkerData : NSObject
 - (instancetype)initWithLabel:(NSString *)label
                          icon:(NSString *)icon
-                  hasTail:(BOOL)hasTail
+                  hasPointer:(BOOL)hasPointer
                    isSelected:(BOOL)isSelected
                    isVisualized:(BOOL)isVisualized
                         state:(NSString *)state
@@ -20,7 +20,7 @@
 @property (nonatomic, strong) NSString *state;
 @property (nonatomic, strong) NSString *variant;
 @property (nonatomic, strong) NSString *size;
-@property (nonatomic, assign) BOOL hasTail;
+@property (nonatomic, assign) BOOL hasPointer;
 @property (nonatomic, assign) BOOL isSelected;
 @property (nonatomic, assign) BOOL isVisualized;
 @end

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.h
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.h
@@ -8,7 +8,7 @@
 @interface CozyMarkerData : NSObject
 - (instancetype)initWithLabel:(NSString *)label
                          icon:(NSString *)icon
-                  hasPointer:(BOOL)hasPointer
+                  hasTail:(BOOL)hasTail
                    isSelected:(BOOL)isSelected
                    isVisualized:(BOOL)isVisualized
                         state:(NSString *)state
@@ -20,7 +20,7 @@
 @property (nonatomic, strong) NSString *state;
 @property (nonatomic, strong) NSString *variant;
 @property (nonatomic, strong) NSString *size;
-@property (nonatomic, assign) BOOL hasPointer;
+@property (nonatomic, assign) BOOL hasTail;
 @property (nonatomic, assign) BOOL isSelected;
 @property (nonatomic, assign) BOOL isVisualized;
 @end

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.m
@@ -10,6 +10,7 @@
 
 @implementation CozyMarkerData
 - (instancetype)initWithLabel:(NSString *)label
+                         icon:(NSString *)icon
                   hasPointer:(BOOL)hasPointer
                    isSelected:(BOOL)isSelected
                    isVisualized:(BOOL)isVisualized
@@ -19,6 +20,7 @@
   self = [super init];
   if (self) {
     _label = label;
+    _icon = icon;
     _hasPointer = hasPointer;
     _isSelected = isSelected;
     _isVisualized = isVisualized;
@@ -30,8 +32,9 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@",
+    return [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@ %@ %@",
             self.label,
+            self.icon,
             self.state,
             self.variant,
             self.size,

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.m
@@ -11,7 +11,7 @@
 @implementation CozyMarkerData
 - (instancetype)initWithLabel:(NSString *)label
                          icon:(NSString *)icon
-                  hasPointer:(BOOL)hasPointer
+                  hasTail:(BOOL)hasTail
                    isSelected:(BOOL)isSelected
                    isVisualized:(BOOL)isVisualized
                         state:(NSString *)state
@@ -21,7 +21,7 @@
   if (self) {
     _label = label;
     _icon = icon;
-    _hasPointer = hasPointer;
+    _hasTail = hasTail;
     _isSelected = isSelected;
     _isVisualized = isVisualized;
     _state = state;
@@ -38,7 +38,7 @@
             self.state,
             self.variant,
             self.size,
-            self.hasPointer ? @"YES" : @"NO",
+            self.hasTail ? @"YES" : @"NO",
             self.isSelected ? @"YES" : @"NO",
             self.isVisualized ? @"YES" : @"NO"];
 }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerData.m
@@ -11,7 +11,7 @@
 @implementation CozyMarkerData
 - (instancetype)initWithLabel:(NSString *)label
                          icon:(NSString *)icon
-                  hasTail:(BOOL)hasTail
+                  hasPointer:(BOOL)hasPointer
                    isSelected:(BOOL)isSelected
                    isVisualized:(BOOL)isVisualized
                         state:(NSString *)state
@@ -21,7 +21,7 @@
   if (self) {
     _label = label;
     _icon = icon;
-    _hasTail = hasTail;
+    _hasPointer = hasPointer;
     _isSelected = isSelected;
     _isVisualized = isVisualized;
     _state = state;
@@ -38,7 +38,7 @@
             self.state,
             self.variant,
             self.size,
-            self.hasTail ? @"YES" : @"NO",
+            self.hasPointer ? @"YES" : @"NO",
             self.isSelected ? @"YES" : @"NO",
             self.isVisualized ? @"YES" : @"NO"];
 }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -210,7 +210,7 @@
 - (void)interpretCozyMarkerData:(NSDictionary *)cozyMarkerDataDict {
     CozyMarkerData *cozyMarkerData = [[CozyMarkerData alloc] initWithLabel:cozyMarkerDataDict[@"label"] 
                                                                 icon:cozyMarkerDataDict[@"icon"]
-                                                                hasTail: [cozyMarkerDataDict[@"hasTail"] boolValue]
+                                                                hasPointer: [cozyMarkerDataDict[@"hasPointer"] boolValue]
                                                                 isSelected: [cozyMarkerDataDict[@"isSelected"] boolValue]
                                                                 isVisualized: [cozyMarkerDataDict[@"isVisualized"] boolValue]
                                                                 state: cozyMarkerDataDict[@"state"]

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -151,13 +151,17 @@
     if (draggable && draggable != (id)[NSNull null]) {
         [self setDraggable:[draggable boolValue]];
     }
-    NSArray *icon = data[@"icon"];
-    if (icon && icon != (id)[NSNull null]) {
-        UIImage *image = [self extractIconFromData:icon registrar:registrar];
-        [self setIcon:image];
-    }
 
-    [self interpretCozyMarkerData:data];
+    NSDictionary *cozyMarkerDataDict = data[@"cozyMarkerData"];
+    if (cozyMarkerDataDict && cozyMarkerDataDict != (id)[NSNull null]) {
+        [self interpretCozyMarkerData:cozyMarkerDataDict];
+    }else{
+        NSArray *icon = data[@"icon"];
+        if (icon && icon != (id)[NSNull null]) {
+            UIImage *image = [self extractIconFromData:icon registrar:registrar];
+            [self setIcon:image];
+        }
+    }
 
     NSNumber *flat = data[@"flat"];
     if (flat && flat != (id)[NSNull null]) {
@@ -203,20 +207,18 @@
     }
 }
 
-- (void)interpretCozyMarkerData:(NSDictionary *)data {
-    NSDictionary *cozyMarkerDataDict = data[@"cozyMarkerData"];
-    if (cozyMarkerDataDict && cozyMarkerDataDict != (id)[NSNull null]) {
-        CozyMarkerData *cozyMarkerData = [[CozyMarkerData alloc] initWithLabel:cozyMarkerDataDict[@"label"] 
-                                                                  hasPointer: [cozyMarkerDataDict[@"hasPointer"] boolValue]
-                                                                  isSelected: [cozyMarkerDataDict[@"isSelected"] boolValue]
-                                                                  isVisualized: [cozyMarkerDataDict[@"isVisualized"] boolValue]
-                                                                  state: cozyMarkerDataDict[@"state"]
-                                                                  variant: cozyMarkerDataDict[@"variant"]
-                                                                  size: cozyMarkerDataDict[@"size"]];
+- (void)interpretCozyMarkerData:(NSDictionary *)cozyMarkerDataDict {
+    CozyMarkerData *cozyMarkerData = [[CozyMarkerData alloc] initWithLabel:cozyMarkerDataDict[@"label"] 
+                                                                icon:cozyMarkerDataDict[@"icon"]
+                                                                hasPointer: [cozyMarkerDataDict[@"hasPointer"] boolValue]
+                                                                isSelected: [cozyMarkerDataDict[@"isSelected"] boolValue]
+                                                                isVisualized: [cozyMarkerDataDict[@"isVisualized"] boolValue]
+                                                                state: cozyMarkerDataDict[@"state"]
+                                                                variant: cozyMarkerDataDict[@"variant"]
+                                                                size: cozyMarkerDataDict[@"size"]];
 
-        UIImage *image = [[self cozy] buildMarkerWithData:cozyMarkerData];
-        [self setIcon:image];
-    }
+    UIImage *image = [[self cozy] buildMarkerWithData:cozyMarkerData];
+    [self setIcon:image];
 }
 
 - (UIImage *)extractIconFromData:(NSArray *)iconData

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -210,7 +210,7 @@
 - (void)interpretCozyMarkerData:(NSDictionary *)cozyMarkerDataDict {
     CozyMarkerData *cozyMarkerData = [[CozyMarkerData alloc] initWithLabel:cozyMarkerDataDict[@"label"] 
                                                                 icon:cozyMarkerDataDict[@"icon"]
-                                                                hasPointer: [cozyMarkerDataDict[@"hasPointer"] boolValue]
+                                                                hasTail: [cozyMarkerDataDict[@"hasTail"] boolValue]
                                                                 isSelected: [cozyMarkerDataDict[@"isSelected"] boolValue]
                                                                 isVisualized: [cozyMarkerDataDict[@"isVisualized"] boolValue]
                                                                 state: cozyMarkerDataDict[@"state"]

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/google_maps_flutter_ios.podspec
@@ -22,6 +22,7 @@ Downloaded by pub (not CocoaPods).
   s.module_map = 'Classes/google_maps_flutter_ios.modulemap'
   s.dependency 'Flutter'
   s.dependency 'GoogleMaps'
+  s.dependency 'SVGKit'
   s.static_framework = true
   s.platform = :ios, '9.0'
   # GoogleMaps does not support arm64 simulators.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker/cozy_marker/cozy_marker_data.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker/cozy_marker/cozy_marker_data.dart
@@ -12,7 +12,7 @@ class CozyMarkerData {
     this.icon,
     this.isVisualized = false,
     this.isSelected = false,
-    this.hasTail = false,
+    this.hasPointer = false,
     this.state = CozyMarkerState.defaultState,
     this.variant = CozyMarkerVariant.defaultVariant,
     this.size = CozyMarkerSize.small,
@@ -30,8 +30,8 @@ class CozyMarkerData {
   /// Wether marker is visualized or not.
   final bool isVisualized;
 
-  /// Wether marker has a little tail below it or not.
-  final bool hasTail;
+  /// Wether marker has a little pointer below it or not.
+  final bool hasPointer;
 
   /// State of the marker
   /// It can have either default or pressed state.
@@ -56,7 +56,7 @@ class CozyMarkerData {
     addIfPresent('label', label);
     addIfPresent('isSelected', isSelected);
     addIfPresent('isVisualized', isVisualized);
-    addIfPresent('hasTail', hasTail);
+    addIfPresent('hasPointer', hasPointer);
     addIfPresent('state', state.name);
     addIfPresent('variant', variant.name);
     addIfPresent('size', size.name);
@@ -77,7 +77,7 @@ class CozyMarkerData {
         label == other.label &&
         isSelected == other.isSelected &&
         isVisualized == other.isVisualized &&
-        hasTail == other.hasTail &&
+        hasPointer == other.hasPointer &&
         state == other.state &&
         variant == other.variant &&
         size == other.size &&
@@ -89,7 +89,7 @@ class CozyMarkerData {
         label,
         isSelected,
         isVisualized,
-        hasTail,
+        hasPointer,
         state,
         variant,
         size,
@@ -98,7 +98,7 @@ class CozyMarkerData {
 
   @override
   String toString() {
-    return 'CozyMarkerData{ label: $label, isSelected: $isSelected, isVisualized: $isVisualized, hasTail: $hasTail, state: ${state.name}, variant: ${variant.name}, size: ${size.name}, icon: $icon }';
+    return 'CozyMarkerData{ label: $label, isSelected: $isSelected, isVisualized: $isVisualized, hasPointer: $hasPointer, state: ${state.name}, variant: ${variant.name}, size: ${size.name}, icon: $icon }';
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker/cozy_marker/cozy_marker_data.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker/cozy_marker/cozy_marker_data.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart'
     show immutable;
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 
 /// CozyMarkerData is the payload necessary to describe all attributes of a CozyMarker.
 /// It follows the same properties described on cozy MapPin component.
@@ -8,6 +9,7 @@ class CozyMarkerData {
   /// Creates CozyMarkerData payload.
   const CozyMarkerData({
     required this.label,
+    this.icon,
     this.isVisualized = false,
     this.isSelected = false,
     this.hasPointer = false,
@@ -18,6 +20,9 @@ class CozyMarkerData {
 
   /// Label of the marker
   final String label;
+
+  /// Icon of the marker in svg format.
+  final String? icon;
 
   /// Wether marker is in selected state or not.
   final bool isSelected;
@@ -55,7 +60,8 @@ class CozyMarkerData {
     addIfPresent('state', state.name);
     addIfPresent('variant', variant.name);
     addIfPresent('size', size.name);
-
+    addIfPresent('icon', icon);
+  
     return json;
   }
 
@@ -74,7 +80,8 @@ class CozyMarkerData {
         hasPointer == other.hasPointer &&
         state == other.state &&
         variant == other.variant &&
-        size == other.size;
+        size == other.size &&
+        icon == other.icon;
   }
 
   @override
@@ -86,11 +93,12 @@ class CozyMarkerData {
         state,
         variant,
         size,
+        icon,
       );
 
   @override
   String toString() {
-    return 'CozyMarkerData{ label: $label, isSelected: $isSelected, isVisualized: $isVisualized, hasPointer: $hasPointer, state: ${state.name}, variant: ${variant.name}, size: ${size.name} }';
+    return 'CozyMarkerData{ label: $label, isSelected: $isSelected, isVisualized: $isVisualized, hasPointer: $hasPointer, state: ${state.name}, variant: ${variant.name}, size: ${size.name}, icon: $icon }';
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker/cozy_marker/cozy_marker_data.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker/cozy_marker/cozy_marker_data.dart
@@ -12,7 +12,7 @@ class CozyMarkerData {
     this.icon,
     this.isVisualized = false,
     this.isSelected = false,
-    this.hasPointer = false,
+    this.hasTail = false,
     this.state = CozyMarkerState.defaultState,
     this.variant = CozyMarkerVariant.defaultVariant,
     this.size = CozyMarkerSize.small,
@@ -30,8 +30,8 @@ class CozyMarkerData {
   /// Wether marker is visualized or not.
   final bool isVisualized;
 
-  /// Wether marker has a little pointer below it or not.
-  final bool hasPointer;
+  /// Wether marker has a little tail below it or not.
+  final bool hasTail;
 
   /// State of the marker
   /// It can have either default or pressed state.
@@ -56,7 +56,7 @@ class CozyMarkerData {
     addIfPresent('label', label);
     addIfPresent('isSelected', isSelected);
     addIfPresent('isVisualized', isVisualized);
-    addIfPresent('hasPointer', hasPointer);
+    addIfPresent('hasTail', hasTail);
     addIfPresent('state', state.name);
     addIfPresent('variant', variant.name);
     addIfPresent('size', size.name);
@@ -77,7 +77,7 @@ class CozyMarkerData {
         label == other.label &&
         isSelected == other.isSelected &&
         isVisualized == other.isVisualized &&
-        hasPointer == other.hasPointer &&
+        hasTail == other.hasTail &&
         state == other.state &&
         variant == other.variant &&
         size == other.size &&
@@ -89,7 +89,7 @@ class CozyMarkerData {
         label,
         isSelected,
         isVisualized,
-        hasPointer,
+        hasTail,
         state,
         variant,
         size,
@@ -98,7 +98,7 @@ class CozyMarkerData {
 
   @override
   String toString() {
-    return 'CozyMarkerData{ label: $label, isSelected: $isSelected, isVisualized: $isVisualized, hasPointer: $hasPointer, state: ${state.name}, variant: ${variant.name}, size: ${size.name}, icon: $icon }';
+    return 'CozyMarkerData{ label: $label, isSelected: $isSelected, isVisualized: $isVisualized, hasTail: $hasTail, state: ${state.name}, variant: ${variant.name}, size: ${size.name}, icon: $icon }';
   }
 }
 


### PR DESCRIPTION
## Description

Adding capability to add icons to markers. 

<image src="https://github.com/fulpismo/plugins/assets/22605271/22a5d5d1-feb5-45da-835b-4faa095e8fcf" width="300"/>



Strategy: Because of performance problems on passing heavy bitmap data from flutter, it was decided to pass just the svg string and render the svg on native side. It has the downside of duplicating code, however it is a scalable and clean approach for the future, where we intend to use a diversity of icons

- For Android, this library was used: https://bigbadaboom.github.io/androidsvg/. It's not an official library, but it's the most popular and most maintained. Researched by alternatives, but no other decent one was found. By tests, it worked pretty well, even for worst devices. It has limited svg capabitiles, but for our needs, seems good.

- For iOS, this library was used: https://github.com/SVGKit/SVGKit. It's a highly supported and have great coverage of svg capabilities (even with svg animations). The main concern here was the bundle size increase, because this library is quite huge and support a lot of functionalities. However, by analyzing the bundle size, it was ok: 

Without SVGKit: 
<img width="689" alt="image" src="https://github.com/fulpismo/plugins/assets/22605271/1ba598d6-011b-4669-a638-43e60a4e7e57">
With SVGKit:
<img width="694" alt="image" src="https://github.com/fulpismo/plugins/assets/22605271/66998b69-5358-459e-8b0d-ffe6ec27dc0a">

To avoid excessive processing, icon caching was also added (the same way we have pin image caching)

## Bonus tasks

- Clean unused code
- Fix some bugs introduced last PR (such as adding default maps icon mistakenly right before the cozyMarker and isVisualized was not affetcting iOS caching)
- Refactored some code of the `CozyMarkerBuilder` to organize it better and to relayout it a little. Because we need really precise proportions with the icon, it was found some really small inconsistencies that were corrected, both for ios and android:

Android before (overlapping figma and rendered version): 
<img width="200" alt="image" src="https://github.com/fulpismo/plugins/assets/22605271/b646e164-158a-41af-8b6f-9cab3b7cc3c1">

iOS before (overlapping figma and rendered version):
<img width="200" alt="image" src="https://github.com/fulpismo/plugins/assets/22605271/4402a4de-b399-4b0b-ac6c-3d95dd044356">
