### PR TITLE
feat(NXP-263): Change color of counter price pin bubble

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,18 +19,18 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter 
 
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_android
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -23,19 +23,19 @@ dependencies:
   google_maps_flutter_android: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_android    
     
   google_maps_flutter_ios: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_ios    
 
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface 
 
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/cozy/CozyMarkerElementsBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/cozy/CozyMarkerElementsBuilder.java
@@ -107,11 +107,13 @@ class CozyMarkerElementsBuilder {
         final int selectedMarkerColor = Color.rgb(57, 87, 189);
         final int selectedTextColor = Color.WHITE;
         final int selectedIconCircleColor = Color.WHITE;
+        final int selectedCounterBubbleColor = Color.rgb(248, 249, 245);
 
         final int visualizedMarkerColor = Color.rgb(217, 219, 208);
         final int visualizedTextColor = Color.BLACK;
         final int visualizedStrokeColor = Color.rgb(197, 201, 186);
         final int visualizedIconCircleColor = Color.WHITE;
+        final int visualizedCounterBubbleColor = Color.rgb(248, 249, 245);
 
         final int specialIconCircleColor = Color.rgb(240, 243, 255);
         final int specialIconColor = Color.rgb(57, 87, 189);
@@ -122,18 +124,21 @@ class CozyMarkerElementsBuilder {
         int strokeColor = defaultStrokeColor;
         int iconCircleColor = defaultIconCircleColor;
         int iconColor = defaultIconColor;
+        int counterBubbleColor = defaultCounterBubbleColor;
 
         if (markerData.isVisualized) {
             markerColor = visualizedMarkerColor;
             textColor = visualizedTextColor;
             strokeColor = visualizedStrokeColor;
             iconCircleColor = visualizedIconCircleColor;
+            counterBubbleColor = visualizedCounterBubbleColor;
         }
         if (markerData.isSelected) {
             markerColor = selectedMarkerColor;
             textColor = selectedTextColor;
             strokeColor = defaultStrokeColor;
             iconCircleColor = selectedIconCircleColor;
+            counterBubbleColor = selectedCounterBubbleColor;
         }
         if (markerData.variant.equals("special") &&
                 (!markerData.isVisualized || markerData.isSelected)) {
@@ -264,7 +269,7 @@ class CozyMarkerElementsBuilder {
                 // Counter bubble
                 new CozyMarkerElement(
                         hasCounter ? new RectF(counterBubbleShapeX, counterBubbleShapeY, counterBubbleShapeX + counterSummaryWidth, counterBubbleShapeY + counterBubbleShapeHeight) : null,
-                        defaultCounterBubbleColor,
+                        counterBubbleColor,
                         defaultStrokeColor
                 ),
                 // Labels

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_android  
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -19,12 +19,12 @@ dependencies:
     # the parent directory to use the current plugin's version.
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_ios
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerElementsBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerElementsBuilder.m
@@ -46,7 +46,7 @@
                                                                                  245.0f /
                                                                                  255.0f)                                 alpha:1];
 
-    UIColor *const counterBubbleColor = [UIColor colorWithRed:(
+    UIColor *const defaultCounterBubbleColor = [UIColor colorWithRed:(
                                                                235.0f / 255.0f)
                                                         green:(237.f /
                                                                255.0f) blue:(
@@ -60,6 +60,12 @@
                                                                                                      189.0f / 255.0f) alpha:1];
     UIColor *const selectedTextColor = UIColor.whiteColor;
     UIColor *const selectedIconCircleColor = UIColor.whiteColor;
+    UIColor *const selectedCounterBubbleColor = [UIColor colorWithRed:(
+                    248.0f / 255.0f)
+                                                            green:(249.f /
+                                                                   255.0f) blue:(
+                    245.0f /
+                    255.0f)                                 alpha:1];
     
     UIColor *const visualizedMarkerColor = [UIColor colorWithRed:(217.0f / 255.0f) green:(219.0f /
                                                                                           255.0f) blue:(
@@ -67,6 +73,12 @@
     UIColor *const visualizedTextColor = UIColor.blackColor;
     UIColor *const visualizedStrokeColor = [UIColor colorWithRed:(197.0f / 255.0f) green:(201.0f / 255.0f) blue:(186.0f / 255.0f) alpha:1];
     UIColor *const visualizedIconCircleColor = UIColor.whiteColor;
+    UIColor *const visualizedCounterBubbleColor = [UIColor colorWithRed:(
+                    248.0f / 255.0f)
+                                                                green:(249.f /
+                                                                       255.0f) blue:(
+                    245.0f /
+                    255.0f)                                 alpha:1];
     
     UIColor *const specialIconCircleColor = [UIColor colorWithRed:(240.0f / 255.0f) green:(243.0f /
                                                                                            255.0f) blue:(
@@ -80,18 +92,21 @@
     UIColor *iconCircleColor = defaultIconCircleColor;
     UIColor *iconColor = defaultIconColor;
     UIColor *strokeColor = defaultStrokeColor;
+    UIColor *counterBubbleColor = defaultCounterBubbleColor;
     
     if (cozyMarkerData.isVisualized) {
         markerColor = visualizedMarkerColor;
         textColor = visualizedTextColor;
         strokeColor = visualizedStrokeColor;
         iconCircleColor = visualizedIconCircleColor;
+        counterBubbleColor = visualizedCounterBubbleColor;
     }
     if (cozyMarkerData.isSelected) {
         markerColor = selectedMarkerColor;
         textColor = selectedTextColor;
         strokeColor = defaultStrokeColor;
         iconCircleColor = selectedIconCircleColor;
+        counterBubbleColor = selectedCounterBubbleColor;
     }
     if ([cozyMarkerData.variant isEqualToString:@"special"] &&
         (!cozyMarkerData.isVisualized || cozyMarkerData.isSelected)) {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
 
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   google_maps_flutter_platform_interface:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface
   google_maps_flutter_web:
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_web
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   google_maps_flutter_platform_interface: 
     git:
       url: https://github.com/fulpismo/plugins.git
-      ref: v2.2.3-fork.13
+      ref: v2.2.3-fork.14
       path: packages/google_maps_flutter/google_maps_flutter_platform_interface    
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0


### PR DESCRIPTION
1. Changed counter bubble color default state to rgb(235, 237, 230, 1), and selected / visualised to rgb(248, 249, 245)
2. Bumped dependencies to v2.2.3-fork.14

<img width="1073" alt="Screenshot 2023-10-23 at 19 36 04" src="https://github.com/fulpismo/plugins/assets/5969391/2dc68ddd-ce79-4d5d-950f-b8951bef8481">
