### PR TITLE
fix(NT-349): Adjusting size and shadows

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/cozy/CozyMarkerBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/cozy/CozyMarkerBuilder.java
@@ -13,6 +13,7 @@ import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Typeface;
+import android.graphics.Matrix;
 
 import com.caverock.androidsvg.SVG;
 
@@ -74,6 +75,7 @@ public class CozyMarkerBuilder {
         final CozyMarkerElement pointer = cozyElements.pointer;
         final CozyMarkerElement markerBubble = cozyElements.bubble;
         final CozyMarkerElement counterBubble = cozyElements.counterBubble;
+        final CozyMarkerElement shadowBubble = cozyElements.shadowBubble;
 
         /* start of drawing */
         // creates the marker bitmap
@@ -116,10 +118,17 @@ public class CozyMarkerBuilder {
         Canvas canvas = new Canvas(marker);
 
         // draws elevation shadow
-        if (cozyElements.shadowBubble.alpha != 0) {
+        if (shadowBubble.alpha != 0) {
             Path shadowPath = new Path();
-            shadowPath.addRoundRect(cozyElements.shadowBubble.bounds, shapeBorderRadius, shapeBorderRadius, Path.Direction.CW);
-            canvas.drawPath(shadowPath, getShadowPaint(cozyElements.shadowBubble.fillColor, cozyElements.shadowBubble.alpha));
+            shadowPath.set(bubblePath);
+
+            Matrix matrix = new Matrix();
+            float dy = shadowBubble.bounds.top - markerBubble.bounds.top;
+            matrix.setTranslate(0, dy);
+
+            // Apply the transformation to the path
+            shadowPath.transform(matrix);
+            canvas.drawPath(shadowPath, getShadowPaint(shadowBubble.fillColor, shadowBubble.alpha));
         }
 
         // draws the bubble with the pointer

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/cozy/CozyMarkerElementsBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/cozy/CozyMarkerElementsBuilder.java
@@ -169,10 +169,10 @@ class CozyMarkerElementsBuilder {
         final float paddingHorizontal = getDpFromPx(11.5f);
         final float minMarkerWidth = getDpFromPx(40);
         final float strokeSize = getDpFromPx(1.5f);
-        final float elevation = hasElevation ? getDpFromPx(4f) : 0;
+        final float elevation = hasElevation ? getDpFromPx(5f) : 0;
         final float totalStrokeSize = strokeSize + elevation;
-        final float shadowDisplacement = getDpFromPx(3f);
-        final float miniPinRadius = getDpFromPx(4.5f);
+        final float shadowDisplacement = getDpFromPx(2f);
+        final float miniPinRadius = getDpFromPx(4f);
         final float miniPinWidth = getDpFromPx(14);
 
         // setting constants for counter
@@ -246,8 +246,8 @@ class CozyMarkerElementsBuilder {
             bubbleShapeHeight = markerHeight - strokeSize;
         }
 
-        float canvasWidth = markerWidth + (2 * elevation);
-        float canvasHeight = markerHeight + (2 * elevation) + pointerSize;
+        float canvasWidth = markerWidth + elevation;
+        float canvasHeight = markerHeight + elevation + pointerSize;
 
         // marker bubble coordinates
         float bubbleShapeX = totalStrokeSize / 2f;
@@ -290,7 +290,9 @@ class CozyMarkerElementsBuilder {
 
         // Pointer coordinates
         float pointerX = canvasWidth / 2f - pointerWidth;
-        float pointerY = canvasHeight - pointerSize - totalStrokeSize;
+        float pointerY = canvasHeight - pointerSize - totalStrokeSize + elevation / 2f;
+
+        float shadowAlpha = hasElevation ? isMiniMarker(markerData.size) ? 0.2f : 0.15f : 0.0f;
 
         return new CozyMarkerElements(
                 // Canvas
@@ -307,7 +309,7 @@ class CozyMarkerElementsBuilder {
                 new CozyMarkerElement(
                         new RectF(bubbleShapeX, bubbleShapeY + shadowDisplacement, bubbleShapeX + bubbleShapeWidth, bubbleShapeY + bubbleShapeHeight + shadowDisplacement),
                         Color.BLACK,
-                        hasElevation ? 0.3f : 0.0f
+                        shadowAlpha
                 ),
                 // Counter bubble
                 new CozyMarkerElement(

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerElementsBuilder.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/CozyMarkerElementsBuilder.m
@@ -150,8 +150,8 @@
     const CGFloat iconRightPadding = 3;
     const CGFloat elevation = hasElevation ? 4 : 0;
     const CGFloat totalStrokeSize = self.strokeSize + elevation;
-    const CGFloat miniPinRadius = 4.5;
-    const CGFloat miniPinWidth = 15;
+    const CGFloat miniPinRadius = 4;
+    const CGFloat miniPinWidth = 14;
     
     // setting constants for coutner
     const CGFloat counterBubblePadding = 6;
@@ -241,6 +241,8 @@
     // pointer coordinates
     CGFloat pointerX = canvasWidth / 2 - pointerWidth;
     CGFloat pointerY = canvasHeight - pointerSize - totalStrokeSize;
+
+    CGFloat shadowAlpha = hasElevation ? [self isMiniMarker:cozyMarkerData.size] ? 0.15 : 0.08 : 0;
     
     return [[CozyMarkerElements alloc] initWithCanvas:[[CozyMarkerElement alloc]
                                                        initWithBounds:CGRectMake(0, 0, canvasWidth, canvasHeight)
@@ -264,7 +266,7 @@
                                                                                          bubbleShapeHeight)
                                                                fillColor:UIColor.blackColor
                                                                strokeColor:nil
-                                                               alpha: hasElevation ? 0.15 : 0
+                                                               alpha: shadowAlpha
                                                                data:nil]
                                                labels:@[[[CozyMarkerElement alloc]
                                                          initWithBounds:CGRectMake(textX,


### PR DESCRIPTION
# Description

- Adjusting size of the mini pins
- Adjusting the shadow intensity and fixing it to use on price pins as well.

iOS

![image](https://github.com/fulpismo/plugins/assets/22605271/2bee6ef0-89f3-4959-b599-658451eb5f8e)

Android

![image](https://github.com/fulpismo/plugins/assets/22605271/c7a14af7-846b-4a26-a4d1-e3788ce59557)
